### PR TITLE
Fix pause/resume actions

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -1,20 +1,23 @@
 pause:
     description: |
-      Cordon the unit, draining all active workloads.
+      Mark the node as unschedulable to prevent new pods from arriving, and
+      evict existing pods.
     params:
       delete-local-data:
         type: boolean
-        description: Force deletion of local storage to enable a drain
+        description: |
+          Continue even if there are pods using emptyDir (local data that will
+          be deleted when the node is drained).
         default: False
       force:
         type: boolean
         description: |
-            Continue even if there are pods not managed by a RC, RS, Job, DS or SS
+          Continue even if there are pods not managed by a
+          ReplicationController, ReplicaSet, Job, DaemonSet or StatefulSet.
         default: False
-
 resume:
     description: |
-      UnCordon the unit, enabling workload scheduling.
+      Mark node as schedulable.
 microbot:
     description: Launch microbot containers
     params:

--- a/actions/pause
+++ b/actions/pause
@@ -1,28 +1,34 @@
-#!/usr/bin/env bash
+#!/usr/local/sbin/charm-env python3
 
-set -ex
+import os
+import subprocess
 
-export PATH=$PATH:/snap/bin
+from charms.layer.kubernetes_common import (
+    get_node_name,
+    kubectl,
+)
 
-DELETE_LOCAL_DATA=$(action-get delete-local-data)
-FORCE=$(action-get force)
+from charmhelpers.core.hookenv import (
+    action_fail,
+    action_get,
+    status_set,
+)
 
-# placeholder for additional flags to the command
-export EXTRA_FLAGS=""
+# make sure the kubectl snap can be found
+os.environ['PATH'] += os.pathsep + os.path.join(os.sep, 'snap', 'bin')
 
-# Determine if we have extra flags
-if [[ "${DELETE_LOCAL_DATA}" == "True" || "${DELETE_LOCAL_DATA}" == "true" ]]; then
-  EXTRA_FLAGS="${EXTRA_FLAGS} --delete-local-data=true"
-fi
+drain_args = ['--ignore-daemonsets']
 
-if [[ "${FORCE}" == "True" || "${FORCE}" == "true" ]]; then
-  EXTRA_FLAGS="${EXTRA_FLAGS} --force"
-fi
+if action_get('delete-local-data'):
+    drain_args.append('--delete-local-data=true')
 
+if action_get('force'):
+    drain_args.append('--force')
 
-# Cordon and drain the unit
-kubectl --kubeconfig=/root/.kube/config cordon $(hostname)
-kubectl --kubeconfig=/root/.kube/config drain $(hostname) ${EXTRA_FLAGS}
+try:
+    kubectl('drain', get_node_name(), *drain_args)
+except subprocess.CalledProcessError as e:
+    action_fail('{}. See unit logs for details.'.format(str(e)))
+    raise
 
-# Set status to indicate the unit is paused and under maintenance.
-status-set 'waiting' 'Kubernetes unit paused'
+status_set('waiting', 'Kubernetes unit paused')

--- a/actions/resume
+++ b/actions/resume
@@ -1,8 +1,25 @@
-#!/usr/bin/env bash
+#!/usr/local/sbin/charm-env python3
 
-set -ex
+import os
+import subprocess
 
-export PATH=$PATH:/snap/bin
+from charms.layer.kubernetes_common import (
+    get_node_name,
+    kubectl,
+)
 
-kubectl --kubeconfig=/root/.kube/config uncordon $(hostname)
-status-set 'active' 'Kubernetes unit resumed'
+from charmhelpers.core.hookenv import (
+    action_fail,
+    status_set,
+)
+
+# make sure the kubectl snap can be found
+os.environ['PATH'] += os.pathsep + os.path.join(os.sep, 'snap', 'bin')
+
+try:
+    kubectl('uncordon', get_node_name())
+except subprocess.CalledProcessError as e:
+    action_fail('{}. See unit logs for details.'.format(str(e)))
+    raise
+
+status_set('active', 'Kubernetes unit resumed')


### PR DESCRIPTION
Fixes
[lp:1824428](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/1824428)

1. Rewrite actions to python so we can used get_host_name() from
   kubernetes_common. Using get_host_name() fixes the issue reported
   in the bug by returning the fqdn if a cloud integrator is being used.
2. Remove the `kubectl cordon` call from the pause action as it's
   redundant - `kubectl drain` *does* a cordon first.
3. Add --ignore-daemonsets as a default arg to `kubectl drain`. DS pods
   can't be drained as they would be immediately rescheduled by the DS
   controller, which ignores 'unschedulable' taints on the node.
4. Update action descriptions to more closely match upstream docs.