### PR TITLE
Add label to inform Juju of cloud

### DIFF
--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -1135,6 +1135,7 @@ def request_integration():
         cloud.tag_instance({
             'kubernetes.io/cluster/{}'.format(cluster_tag): 'owned',
             'juju.io/cloud': 'ec2',
+            'juju.io/az': os.environ.get('JUJU_AVAILABILITY_ZONE', ''),
         })
         cloud.tag_instance_security_group({
             'kubernetes.io/cluster/{}'.format(cluster_tag): 'owned',
@@ -1148,6 +1149,7 @@ def request_integration():
         cloud.label_instance({
             'k8s-io-cluster-name': cluster_tag,
             'juju.io/cloud': 'gce',
+            'juju.io/az': os.environ.get('JUJU_AVAILABILITY_ZONE', ''),
         })
         cloud.enable_object_storage_management()
     elif is_state('endpoint.azure.joined'):
@@ -1155,6 +1157,7 @@ def request_integration():
         cloud.tag_instance({
             'k8s-io-cluster-name': cluster_tag,
             'juju.io/cloud': 'azure',
+            'juju.io/az': os.environ.get('JUJU_AVAILABILITY_ZONE', ''),
         })
         cloud.enable_object_storage_management()
     cloud.enable_instance_inspection()

--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -1134,6 +1134,7 @@ def request_integration():
         cloud = endpoint_from_flag('endpoint.aws.joined')
         cloud.tag_instance({
             'kubernetes.io/cluster/{}'.format(cluster_tag): 'owned',
+            'juju.io/cloud': 'ec2',
         })
         cloud.tag_instance_security_group({
             'kubernetes.io/cluster/{}'.format(cluster_tag): 'owned',
@@ -1146,12 +1147,14 @@ def request_integration():
         cloud = endpoint_from_flag('endpoint.gcp.joined')
         cloud.label_instance({
             'k8s-io-cluster-name': cluster_tag,
+            'juju.io/cloud': 'gce',
         })
         cloud.enable_object_storage_management()
     elif is_state('endpoint.azure.joined'):
         cloud = endpoint_from_flag('endpoint.azure.joined')
         cloud.tag_instance({
             'k8s-io-cluster-name': cluster_tag,
+            'juju.io/cloud': 'azure',
         })
         cloud.enable_object_storage_management()
     cloud.enable_instance_inspection()


### PR DESCRIPTION
To manage storage intelligently on k8s models, Juju needs to know what cloud the cluster is running on.

Fixes [lp:1824908](https://bugs.launchpad.net/charm-kubernetes-master/+bug/1824908)