### PR TITLE
Moving kube-proxy config option to layer-kubernetes-master-worker-base

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -38,15 +38,6 @@ options:
         --runtime-config=batch/v2alpha1=true --profiling=true
       Note: As of Kubernetes 1.10.x, many of Kubelet's args have been deprecated, and can
       be set with kubelet-extra-config instead.
-  proxy-extra-args:
-    type: string
-    default: ""
-    description: |
-      Space separated list of flags and key=value pairs that will be passed as arguments to
-      kube-proxy. For example a value like this:
-        runtime-config=batch/v2alpha1=true profiling=true
-      will result in kube-apiserver being run with the following options:
-        --runtime-config=batch/v2alpha1=true --profiling=true
   docker-logins:
     type: string
     default: "[]"


### PR DESCRIPTION
Requires: https://github.com/charmed-kubernetes/layer-kubernetes-master-worker-base/pull/3