### PR TITLE
Switch to external OpenStack cloud provider

### DIFF
--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -1133,8 +1133,6 @@ def request_integration():
         cloud = endpoint_from_flag('endpoint.aws.joined')
         cloud.tag_instance({
             'kubernetes.io/cluster/{}'.format(cluster_tag): 'owned',
-            'juju-io-cloud': 'ec2',
-            'juju-io-az': os.environ.get('JUJU_AVAILABILITY_ZONE', ''),
         })
         cloud.tag_instance_security_group({
             'kubernetes.io/cluster/{}'.format(cluster_tag): 'owned',
@@ -1147,16 +1145,12 @@ def request_integration():
         cloud = endpoint_from_flag('endpoint.gcp.joined')
         cloud.label_instance({
             'k8s-io-cluster-name': cluster_tag,
-            'juju-io-cloud': 'gce',
-            'juju-io-az': os.environ.get('JUJU_AVAILABILITY_ZONE', ''),
         })
         cloud.enable_object_storage_management()
     elif is_state('endpoint.azure.joined'):
         cloud = endpoint_from_flag('endpoint.azure.joined')
         cloud.tag_instance({
             'k8s-io-cluster-name': cluster_tag,
-            'juju-io-cloud': 'azure',
-            'juju-io-az': os.environ.get('JUJU_AVAILABILITY_ZONE', ''),
         })
         cloud.enable_object_storage_management()
     cloud.enable_instance_inspection()

--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -53,7 +53,6 @@ from charms.layer.kubernetes_common import configure_kubernetes_service
 from charms.layer.kubernetes_common import parse_extra_args
 from charms.layer.kubernetes_common import cloud_config_path
 from charms.layer.kubernetes_common import write_gcp_snap_config
-from charms.layer.kubernetes_common import write_openstack_snap_config
 from charms.layer.kubernetes_common import write_azure_snap_config
 from charms.layer.kubernetes_common import kubeproxyconfig_path
 from charms.layer.kubernetes_common import configure_kube_proxy
@@ -665,8 +664,7 @@ def configure_kubelet(dns, ingress_ip):
         kubelet_opts['cloud-provider'] = 'gce'
         kubelet_opts['cloud-config'] = str(kubelet_cloud_config_path)
     elif is_state('endpoint.openstack.ready'):
-        kubelet_opts['cloud-provider'] = 'openstack'
-        kubelet_opts['cloud-config'] = str(kubelet_cloud_config_path)
+        kubelet_opts['cloud-provider'] = 'external'
     elif is_state('endpoint.vsphere.joined'):
         # vsphere just needs to be joined on the worker (vs 'ready')
         kubelet_opts['cloud-provider'] = 'vsphere'
@@ -1195,19 +1193,10 @@ def cloud_ready():
     remove_state('kubernetes-worker.cloud.pending')
     if is_state('endpoint.gcp.ready'):
         write_gcp_snap_config('kubelet')
-    elif is_state('endpoint.openstack.ready'):
-        write_openstack_snap_config('kubelet')
     elif is_state('endpoint.azure.ready'):
         write_azure_snap_config('kubelet')
     set_state('kubernetes-worker.cloud.ready')
     set_state('kubernetes-worker.restart-needed')  # force restart
-
-
-@when('kubernetes-worker.cloud.ready',
-      'endpoint.openstack.ready.changed')
-def update_openstack():
-    remove_state('kubernetes-worker.cloud.ready')
-    remove_state('endpoint.openstack.ready.changed')
 
 
 def get_first_mount(mount_relation):


### PR DESCRIPTION
The in-tree cloud providers are being transitioned to external providers using the cloud-controller-manager plugin model.  The in-tree OpenStack provider has already been deprecated, so this switches the charms to use the external provider and the Cinder CSI plugin.

Depends on: https://github.com/charmed-kubernetes/charm-kubernetes-master/pull/15