### PR TITLE
Fix Juju Cloud / AZ tags for character restrictions

### DIFF
--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -1133,8 +1133,8 @@ def request_integration():
         cloud = endpoint_from_flag('endpoint.aws.joined')
         cloud.tag_instance({
             'kubernetes.io/cluster/{}'.format(cluster_tag): 'owned',
-            'juju.io/cloud': 'ec2',
-            'juju.io/az': os.environ.get('JUJU_AVAILABILITY_ZONE', ''),
+            'juju-io-cloud': 'ec2',
+            'juju-io-az': os.environ.get('JUJU_AVAILABILITY_ZONE', ''),
         })
         cloud.tag_instance_security_group({
             'kubernetes.io/cluster/{}'.format(cluster_tag): 'owned',
@@ -1147,16 +1147,16 @@ def request_integration():
         cloud = endpoint_from_flag('endpoint.gcp.joined')
         cloud.label_instance({
             'k8s-io-cluster-name': cluster_tag,
-            'juju.io/cloud': 'gce',
-            'juju.io/az': os.environ.get('JUJU_AVAILABILITY_ZONE', ''),
+            'juju-io-cloud': 'gce',
+            'juju-io-az': os.environ.get('JUJU_AVAILABILITY_ZONE', ''),
         })
         cloud.enable_object_storage_management()
     elif is_state('endpoint.azure.joined'):
         cloud = endpoint_from_flag('endpoint.azure.joined')
         cloud.tag_instance({
             'k8s-io-cluster-name': cluster_tag,
-            'juju.io/cloud': 'azure',
-            'juju.io/az': os.environ.get('JUJU_AVAILABILITY_ZONE', ''),
+            'juju-io-cloud': 'azure',
+            'juju-io-az': os.environ.get('JUJU_AVAILABILITY_ZONE', ''),
         })
         cloud.enable_object_storage_management()
     cloud.enable_instance_inspection()


### PR DESCRIPTION
GCP and Azure have character restrictions on tag / label names that the new juju.io/cloud and juju.io/az tags were violating.  This changes them to use the dash format instead of dot-and-slash, and changes AWS to match to make the logic easier.

Fixes [lp:1827528](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/1827528)