### PR TITLE
[stable] Prevent to remove /srv/kubernetes directory when upgrading

### DIFF
--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -191,7 +191,6 @@ def cleanup_pre_snap_services():
         "/etc/default/kube-default",
         "/etc/default/kubelet",
         "/etc/default/kube-proxy",
-        "/srv/kubernetes",
         "/usr/local/bin/kubectl",
         "/usr/local/bin/kubelet",
         "/usr/local/bin/kube-proxy",


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/charm-kubeapi-load-balancer/+bug/1825288 in stable branch.

Cherry-pick of https://github.com/charmed-kubernetes/charm-kubernetes-worker/pull/5