### PR TITLE
use canonical registry for worker oci images

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -34,7 +34,7 @@ options:
       Space separated list of flags and key=value pairs that will be passed as arguments to
       kubelet. For example a value like this:
         runtime-config=batch/v2alpha1=true profiling=true
-      will result in kube-apiserver being run with the following options:
+      will result in kubelet being run with the following options:
         --runtime-config=batch/v2alpha1=true --profiling=true
       Note: As of Kubernetes 1.10.x, many of Kubelet's args have been deprecated, and can
       be set with kubelet-extra-config instead.


### PR DESCRIPTION
We'll eventually have support for a single 'image-registry' config option to set the location of all container images used in K8s:

https://bugs.launchpad.net/charm-kubernetes-master/+bug/1828853

Lay that framework and set the static images used by K8s workers to the canonical registry. These are pushed by CI during the build of cdk-addons.