### PR TITLE
use configured image-registry when available

### DIFF
--- a/actions/microbot
+++ b/actions/microbot
@@ -20,6 +20,8 @@ import sys
 from charmhelpers.core.hookenv import action_get
 from charmhelpers.core.hookenv import action_set
 from charmhelpers.core.hookenv import unit_public_ip
+from charmhelpers.core.hookenv import config
+from charms.reactive import endpoint_from_flag
 from charms.templating.jinja2 import render
 from subprocess import call, check_output
 
@@ -59,8 +61,13 @@ if context['delete']:
                    'Failed removal of microbot service resource.'})
     sys.exit(0)
 
-# Creation request
+kube_control = endpoint_from_flag('kube-control.registry_location.available')
+if kube_control:
+    registry_location = kube_control.get_registry_location()
+    context['registry'] = registry_location
 
+# Creation request
+ETCD_PORT = config('management_port')
 render('microbot-example.yaml', '/root/cdk/addons/microbot.yaml',
        context)
 

--- a/actions/microbot
+++ b/actions/microbot
@@ -20,7 +20,6 @@ import sys
 from charmhelpers.core.hookenv import action_get
 from charmhelpers.core.hookenv import action_set
 from charmhelpers.core.hookenv import unit_public_ip
-from charmhelpers.core.hookenv import config
 from charms.reactive import endpoint_from_flag
 from charms.templating.jinja2 import render
 from subprocess import call, check_output
@@ -67,7 +66,6 @@ if kube_control:
     context['registry'] = registry_location
 
 # Creation request
-ETCD_PORT = config('management_port')
 render('microbot-example.yaml', '/root/cdk/addons/microbot.yaml',
        context)
 

--- a/actions/registry
+++ b/actions/registry
@@ -25,6 +25,7 @@ from base64 import b64encode
 from charmhelpers.core.hookenv import action_get
 from charmhelpers.core.hookenv import action_set
 from charms.templating.jinja2 import render
+from charms.reactive import endpoint_from_flag
 from subprocess import call, check_output
 
 os.environ['PATH'] += os.pathsep + os.path.join(os.sep, 'snap', 'bin')
@@ -78,6 +79,11 @@ if deletion:
         action_set({'registry-delete': 'failure'})
 
     sys.exit(0)
+
+kube_control = endpoint_from_flag('kube-control.registry_location.available')
+if kube_control:
+    registry_location = kube_control.get_registry_location()
+    context['registry'] = registry_location
 
 # Creation request
 render('registry.yaml', '/root/cdk/addons/registry.yaml',

--- a/config.yaml
+++ b/config.yaml
@@ -34,7 +34,7 @@ options:
       Space separated list of flags and key=value pairs that will be passed as arguments to
       kubelet. For example a value like this:
         runtime-config=batch/v2alpha1=true profiling=true
-      will result in kube-apiserver being run with the following options:
+      will result in kubelet being run with the following options:
         --runtime-config=batch/v2alpha1=true --profiling=true
       Note: As of Kubernetes 1.10.x, many of Kubelet's args have been deprecated, and can
       be set with kubelet-extra-config instead.

--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -751,6 +751,10 @@ def configure_kubelet(dns, ingress_ip):
     if get_version('kubelet') >= (1, 11):
         kubelet_opts['dynamic-config-dir'] = '/root/cdk/kubelet/dynamic-config'
 
+    # An image-registry can be configured on the k8s-master, which is passed to
+    # workers via the kube-control relation. When present, make sure kubelet
+    # gets the pause container from the configured registry. When not present,
+    # kubelet uses a default image location (currently k8s.gcr.io/pause:3.1).
     if is_state('kube-control.registry_location.available'):
         kube_control = endpoint_from_flag(
             'kube-control.registry_location.available')
@@ -795,8 +799,9 @@ def render_and_launch_ingress():
     addon_path = '/root/cdk/addons/{}'
     context['juju_application'] = hookenv.service_name()
 
-    # image-registry config comes from the kuberentes-master charm,
-    # which is passed to the workers on the kube-control interface
+    # An image-registry can be configured on the k8s-master, which is passed to
+    # workers via the kube-control relation. When present, make sure workers
+    # get the ingress containers from the configured registry.
     if is_state('kube-control.registry_location.available'):
         kube_control = endpoint_from_flag(
             'kube-control.registry_location.available')
@@ -1284,6 +1289,9 @@ def nfs_storage(mount):
     if not mount_data:
         return
 
+    # If an image-registry has been configured on the k8s-master, it will be
+    # set on the kube-control relation. Ensure we use it to define the nfs
+    # image location if present.
     if is_state('kube-control.registry_location.available'):
         kube_control = endpoint_from_flag(
             'kube-control.registry_location.available')

--- a/templates/microbot-example.yaml
+++ b/templates/microbot-example.yaml
@@ -18,7 +18,7 @@ spec:
         app: microbot
     spec:
       containers:
-      - image: {{ registry ~ "/" }}cdkbot/microbot-{{ arch }}:latest
+      - image: {{ registry|default("docker.io") }}/cdkbot/microbot-{{ arch }}:latest
         imagePullPolicy: ""
         name: microbot
         ports:

--- a/templates/microbot-example.yaml
+++ b/templates/microbot-example.yaml
@@ -18,7 +18,7 @@ spec:
         app: microbot
     spec:
       containers:
-      - image: cdkbot/microbot-{{ arch }}:latest
+      - image: {{ registry ~ "/" }}cdkbot/microbot-{{ arch }}:latest
         imagePullPolicy: ""
         name: microbot
         ports:

--- a/templates/nfs-provisioner.yaml
+++ b/templates/nfs-provisioner.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: nfs-client-provisioner
-          image: quay.io/external_storage/nfs-client-provisioner:latest
+          image: {{registry|default('quay.io')}}/external_storage/nfs-client-provisioner:latest
           volumeMounts:
             - name: nfs-client-root
               mountPath: /persistentvolumes

--- a/templates/registry.yaml
+++ b/templates/registry.yaml
@@ -37,7 +37,7 @@ spec:
     spec:
       containers:
       - name: registry
-        image: cdkbot/registry-{{ arch }}:2.6
+        image: {{ registry ~ "/" }}cdkbot/registry-{{ arch }}:2.6
         resources:
           # keep request = limit to keep this container in guaranteed class
           limits:

--- a/templates/registry.yaml
+++ b/templates/registry.yaml
@@ -37,7 +37,7 @@ spec:
     spec:
       containers:
       - name: registry
-        image: {{ registry ~ "/" }}cdkbot/registry-{{ arch }}:2.6
+        image: {{ registry|default("docker.io") }}/cdkbot/registry-{{ arch }}:2.6
         resources:
           # keep request = limit to keep this container in guaranteed class
           limits:


### PR DESCRIPTION
Similar to https://github.com/charmed-kubernetes/charm-kubernetes-master/pull/24, pick up where @hyperbolic2346 started this adventure.  We want k8s-workers to use any configured `image-registry` that our k8s-masters have sent on the `kube-control` relation.