### PR TITLE
Handle updates to certs or CA info

### DIFF
--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -585,10 +585,12 @@ def config_changed_requires_restart():
     set_state('kubernetes-worker.restart-needed')
 
 
-@when('tls_client.certs.changed')
+@when_any('tls_client.certs.changed',
+          'tls_client.ca.written')
 def restart_for_certs():
     set_state('kubernetes-worker.restart-needed')
     remove_state('tls_client.certs.changed')
+    remove_state('tls_client.ca.written')
 
 
 def create_config(server, creds):

--- a/templates/default-http-backend.yaml
+++ b/templates/default-http-backend.yaml
@@ -6,6 +6,7 @@ metadata:
     app.kubernetes.io/name: default-http-backend-{{ juju_application }}
     app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
     cdk-{{ juju_application }}-ingress: "true"
+    cdk-ingress: "true"
   namespace: ingress-nginx-{{ juju_application }}
 spec:
   replicas: 1
@@ -52,6 +53,7 @@ metadata:
     app.kubernetes.io/name: default-http-backend-{{ juju_application }}
     app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
     cdk-{{ juju_application }}-ingress: "true"
+    cdk-ingress: "true"
 spec:
   ports:
   - port: 80

--- a/templates/default-http-backend.yaml
+++ b/templates/default-http-backend.yaml
@@ -6,7 +6,6 @@ metadata:
     app.kubernetes.io/name: default-http-backend-{{ juju_application }}
     app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
     cdk-{{ juju_application }}-ingress: "true"
-    cdk-ingress: "true"
   namespace: ingress-nginx-{{ juju_application }}
 spec:
   replicas: 1
@@ -53,7 +52,6 @@ metadata:
     app.kubernetes.io/name: default-http-backend-{{ juju_application }}
     app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
     cdk-{{ juju_application }}-ingress: "true"
-    cdk-ingress: "true"
 spec:
   ports:
   - port: 80

--- a/templates/default-http-backend.yaml
+++ b/templates/default-http-backend.yaml
@@ -6,6 +6,7 @@ metadata:
     app.kubernetes.io/name: default-http-backend-{{ juju_application }}
     app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
     cdk-{{ juju_application }}-ingress: "true"
+    cdk-restart-on-ca-change: "true"
   namespace: ingress-nginx-{{ juju_application }}
 spec:
   replicas: 1

--- a/templates/ingress-daemon-set.yaml
+++ b/templates/ingress-daemon-set.yaml
@@ -4,6 +4,7 @@ metadata:
   name: ingress-nginx-{{ juju_application }}
   labels:
     cdk-{{ juju_application }}-ingress: "true"
+    cdk-ingress: "true"
 
 ---
 kind: ConfigMap
@@ -15,6 +16,7 @@ metadata:
     app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
     app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
     cdk-{{ juju_application }}-ingress: "true"
+    cdk-ingress: "true"
 
 ---
 kind: ConfigMap
@@ -26,6 +28,7 @@ metadata:
     app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
     app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
     cdk-{{ juju_application }}-ingress: "true"
+    cdk-ingress: "true"
 
 ---
 kind: ConfigMap
@@ -37,6 +40,7 @@ metadata:
     app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
     app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
     cdk-{{ juju_application }}-ingress: "true"
+    cdk-ingress: "true"
 
 ---
 apiVersion: v1
@@ -48,6 +52,7 @@ metadata:
     app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
     app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
     cdk-{{ juju_application }}-ingress: "true"
+    cdk-ingress: "true"
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -58,6 +63,7 @@ metadata:
     app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
     app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
     cdk-{{ juju_application }}-ingress: "true"
+    cdk-ingress: "true"
 rules:
   - apiGroups:
       - ""
@@ -116,6 +122,7 @@ metadata:
     app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
     app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
     cdk-{{ juju_application }}-ingress: "true"
+    cdk-ingress: "true"
 rules:
   - apiGroups:
       - ""
@@ -162,6 +169,7 @@ metadata:
     app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
     app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
     cdk-{{ juju_application }}-ingress: "true"
+    cdk-ingress: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -180,6 +188,7 @@ metadata:
     app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
     app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
     cdk-{{ juju_application }}-ingress: "true"
+    cdk-ingress: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -200,6 +209,7 @@ metadata:
     app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
     juju-application: nginx-ingress-{{ juju_application }}
     cdk-{{ juju_application }}-ingress: "true"
+    cdk-ingress: "true"
 spec:
   selector:
     matchLabels:

--- a/templates/ingress-daemon-set.yaml
+++ b/templates/ingress-daemon-set.yaml
@@ -4,7 +4,6 @@ metadata:
   name: ingress-nginx-{{ juju_application }}
   labels:
     cdk-{{ juju_application }}-ingress: "true"
-    cdk-ingress: "true"
 
 ---
 kind: ConfigMap
@@ -16,7 +15,6 @@ metadata:
     app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
     app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
     cdk-{{ juju_application }}-ingress: "true"
-    cdk-ingress: "true"
 
 ---
 kind: ConfigMap
@@ -28,7 +26,6 @@ metadata:
     app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
     app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
     cdk-{{ juju_application }}-ingress: "true"
-    cdk-ingress: "true"
 
 ---
 kind: ConfigMap
@@ -40,7 +37,6 @@ metadata:
     app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
     app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
     cdk-{{ juju_application }}-ingress: "true"
-    cdk-ingress: "true"
 
 ---
 apiVersion: v1
@@ -52,7 +48,6 @@ metadata:
     app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
     app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
     cdk-{{ juju_application }}-ingress: "true"
-    cdk-ingress: "true"
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -63,7 +58,6 @@ metadata:
     app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
     app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
     cdk-{{ juju_application }}-ingress: "true"
-    cdk-ingress: "true"
 rules:
   - apiGroups:
       - ""
@@ -122,7 +116,6 @@ metadata:
     app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
     app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
     cdk-{{ juju_application }}-ingress: "true"
-    cdk-ingress: "true"
 rules:
   - apiGroups:
       - ""
@@ -169,7 +162,6 @@ metadata:
     app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
     app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
     cdk-{{ juju_application }}-ingress: "true"
-    cdk-ingress: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -188,7 +180,6 @@ metadata:
     app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
     app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
     cdk-{{ juju_application }}-ingress: "true"
-    cdk-ingress: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -209,7 +200,6 @@ metadata:
     app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
     juju-application: nginx-ingress-{{ juju_application }}
     cdk-{{ juju_application }}-ingress: "true"
-    cdk-ingress: "true"
 spec:
   selector:
     matchLabels:

--- a/templates/ingress-daemon-set.yaml
+++ b/templates/ingress-daemon-set.yaml
@@ -200,6 +200,7 @@ metadata:
     app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
     juju-application: nginx-ingress-{{ juju_application }}
     cdk-{{ juju_application }}-ingress: "true"
+    cdk-restart-on-ca-change: "true"
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
If the certificates or CA info is updated (re-issued, transferred to a different CA, etc), the charm needs to handle that by updating the files on disk (already done) and restarting the services (added here).