### PR TITLE
Remove non-existent kubelet option: require-kubeconfig

### DIFF
--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -626,7 +626,6 @@ def merge_kubelet_extra_config(config, extra_config):
 
 def configure_kubelet(dns, ingress_ip):
     kubelet_opts = {}
-    kubelet_opts['require-kubeconfig'] = 'true'
     kubelet_opts['kubeconfig'] = kubeconfig_path
     kubelet_opts['network-plugin'] = 'cni'
     kubelet_opts['v'] = '0'


### PR DESCRIPTION
Part of fixing https://bugs.launchpad.net/charm-kubernetes-master/+bug/1841199

The require-kubeconfig option doesn't exist in k8s 1.16.0-beta.0:
```
F0823 17:08:41.495180    6930 server.go:153] unknown flag: --require-kubeconfig
```

Looking as far back as k8s 1.13, the docs do not reference this option at all. I think it's safe to remove it.