### PR TITLE
reconfigure/restart kubelet on registry change

### DIFF
--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -1256,11 +1256,18 @@ def nfs_storage(mount):
 
 @when('kube-control.registry_location.available')
 def update_registry_location():
+    """Handle changes to the container image registry.
+    
+    Monitor the image registry location. If it changes, manage flags to ensure
+    our image-related handlers will be invoked with an accurate registry.
+    """
     registry_location = get_registry_location()
 
     if data_changed('registry-location', registry_location):
-        remove_state('nfs.configured')
+        remove_state('kubernetes-worker.config.created')
         remove_state('kubernetes-worker.ingress.available')
+        remove_state('nfs.configured')
+        set_state('kubernetes-worker.restart-needed')
 
 
 def get_registry_location():

--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -1257,7 +1257,7 @@ def nfs_storage(mount):
 @when('kube-control.registry_location.available')
 def update_registry_location():
     """Handle changes to the container image registry.
-    
+
     Monitor the image registry location. If it changes, manage flags to ensure
     our image-related handlers will be invoked with an accurate registry.
     """


### PR DESCRIPTION
Previously, when an image registry change was detected, we would reconfigure nfs and ingress to ensure images were pulled from the configured registry.  We missed the `pause` image, which also comes from the registry and is one of the first things pulled when starting kubelet.

From [lp 1841438](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/1841438), if kubelet comes up in a network-restricted env *before* the registry is available on the kube-control relation, it will try (and fail) to pull the `pause` image from the default upstream location.

This PR ensures kubelet is reconfigured and restarted any time the registry config changes.