### PR TITLE
Fixing deprecation of apiversions

### DIFF
--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -815,10 +815,16 @@ def render_and_launch_ingress():
                                                   images.get(context['arch'],
                                                              images['amd64']))
 
-    if get_version('kubelet') < (1, 9):
+    kubelet_version = get_version('kubelet')
+    if kubelet_version < (1, 9):
         context['daemonset_api_version'] = 'extensions/v1beta1'
-    else:
+        context['deployment_api_version'] = 'extensions/v1beta1'
+    elif kubelet_version < (1, 16):
         context['daemonset_api_version'] = 'apps/v1beta2'
+        context['deployment_api_version'] = 'extensions/v1beta1'
+    else:
+        context['daemonset_api_version'] = 'apps/v1'
+        context['deployment_api_version'] = 'apps/v1'
     manifest = addon_path.format('ingress-daemon-set.yaml')
     render('ingress-daemon-set.yaml', manifest, context)
     hookenv.log('Creating the ingress daemon set.')

--- a/templates/default-http-backend.yaml
+++ b/templates/default-http-backend.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: {{ deployment_api_version }}
 kind: Deployment
 metadata:
   name: default-http-backend-{{ juju_application }}


### PR DESCRIPTION
See https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/ for a list.
Soon we'll need to update for Ingress, which is used for microbot and registry.

Fixes https://bugs.launchpad.net/cdk-addons/+bug/1841674