### PR TITLE
Update CNI plugins and nginx-ingress-controller for 1.16

### DIFF
--- a/build-cni-resources.sh
+++ b/build-cni-resources.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-CNI_VERSION="${CNI_VERSION:-v0.7.4}"
+CNI_VERSION="${CNI_VERSION:-v0.7.5}"
 ARCH="${ARCH:-amd64 arm64 s390x}"
 
 build_script_commit="$(git show --oneline -q)"

--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -809,8 +809,8 @@ def render_and_launch_ingress():
             nginx_registry = registry_location
         else:
             nginx_registry = 'quay.io'
-        images = {'amd64': 'kubernetes-ingress-controller/nginx-ingress-controller-amd64:0.22.0',  # noqa
-                  'arm64': 'kubernetes-ingress-controller/nginx-ingress-controller-arm64:0.22.0',  # noqa
+        images = {'amd64': 'kubernetes-ingress-controller/nginx-ingress-controller-amd64:0.25.1',  # noqa
+                  'arm64': 'kubernetes-ingress-controller/nginx-ingress-controller-arm64:0.25.1',  # noqa
                   's390x': 'kubernetes-ingress-controller/nginx-ingress-controller-s390x:0.20.0',  # noqa
                   'ppc64el': 'kubernetes-ingress-controller/nginx-ingress-controller-ppc64le:0.20.0',  # noqa
                  }

--- a/templates/ingress-daemon-set.yaml
+++ b/templates/ingress-daemon-set.yaml
@@ -85,14 +85,6 @@ rules:
       - list
       - watch
   - apiGroups:
-      - "extensions"
-    resources:
-      - ingresses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - ""
     resources:
       - events
@@ -101,11 +93,20 @@ rules:
       - patch
   - apiGroups:
       - "extensions"
+      - "networking.k8s.io"
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "extensions"
+      - "networking.k8s.io"
     resources:
       - ingresses/status
     verbs:
       - update
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/charm-kubernetes-worker/+bug/1841838

Depends on https://github.com/charmed-kubernetes/bundle/pull/745

* Updated CNI plugins to 0.7.5, which is the version that upstream will ship with k8s 1.16 ([source 1](https://github.com/kubernetes/kubernetes/blob/release-1.16/test/e2e_node/remote/utils.go#L30), [source 2](https://github.com/kubernetes/kubernetes/blob/release-1.16/build/rpms/kubelet.spec#L14)).
* Updated nginx-ingress-controller to 0.25.1, which is the latest version ([source](https://github.com/kubernetes/ingress-nginx/releases)).
* Checked default-http-backend, no new versions.

I tested using a local [bundle.yaml](https://gist.github.com/Cynerva/4ab2bd141b694dc5b9d6dcbdf67112d1) that includes components from this PR along with [cdk-addons#143](https://github.com/charmed-kubernetes/cdk-addons/pull/143) and [charm-flannel#56](https://github.com/charmed-kubernetes/charm-flannel/pull/56). I deployed the bundle and ran validation with "slow" tests skipped:
```
$ pytest -s --no-print-logs -m "not slow" validation.py --controller aws-dev --model test2
...
Results (937.29s):
      16 passed
       4 skipped
       1 deselected
```

I manually ran the microbot action and accessed the output URL in my browser, to confirm ingress works with these updates.