### PR TITLE
ports-to-open config added

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -92,3 +92,11 @@ options:
 
       For more information about KubeletConfiguration, see upstream docs:
       https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/
+  ports-to-open:
+    default: "80,443"
+    type: string
+    description: |
+      Comma-separated list of ports to be opened on each worker node. Ports will
+      be opened using juju's open-port command. By default, 80 and 443 are opened
+      for ingress controller.
+


### PR DESCRIPTION
Due to: https://bugs.launchpad.net/charm-kubernetes-worker/+bug/1842104, this charm cannot manage opening or closing ports besides 80 and 443 when ingress option is set to True.
Option ports-to-open allows to setup a comma-separated list of ports to be opened by kubernetes-worker charm.

Closes-Bug: LP #1842104