### PR TITLE
Add support for snap coherence

### DIFF
--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -76,6 +76,8 @@ checksum_prefix = 'kubernetes-worker.resource-checksums.'
 configure_prefix = 'kubernetes-worker.prev_args.'
 cpu_manager_state = "/var/lib/kubelet/cpu_manager_state"
 
+cohort_snaps = ['kubectl', 'kubelet', 'kube-proxy']
+
 os.environ['PATH'] += os.pathsep + os.path.join(os.sep, 'snap', 'bin')
 db = unitdata.kv()
 
@@ -225,6 +227,14 @@ def install_snaps():
     set_state('kubernetes-worker.restart-needed')
     remove_state('kubernetes-worker.snaps.upgrade-needed')
     remove_state('kubernetes-worker.snaps.upgrade-specified')
+
+
+@when('kubernetes-worker.snaps.installed',
+      'kube-control.cohort_keys.available')
+def join_or_update_cohorts():
+    kube_control = endpoint_from_flag('kube-control.cohort_keys.available')
+    for snapname in cohort_snaps:
+        snap.join_cohort_snapshot(snapname, kube_control.cohort_keys[snapname])
 
 
 @hook('stop')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ sys.modules['charmhelpers.contrib'] = ch.contrib
 sys.modules['charmhelpers.contrib.charmsupport'] = ch.contrib.charmsupport
 charms = MagicMock()
 sys.modules['charms'] = charms
+sys.modules['charms.coordinator'] = charms.coordinator
 sys.modules['charms.layer'] = charms.layer
 sys.modules['charms.layer.hacluster'] = charms.layer.hacluster
 sys.modules['charms.layer.kubernetes_common'] = charms.layer.kubernetes_common


### PR DESCRIPTION
Allow the master to manage when point release refreshes of snaps are applied.

Depends on:
https://github.com/charmed-kubernetes/layer-snap/pull/1
https://github.com/charmed-kubernetes/jenkins/pull/546
https://github.com/charmed-kubernetes/layer-kubernetes-master-worker-base/pull/10
https://github.com/juju-solutions/interface-kube-control/pull/28