### PR TITLE
Adding Nagios plugin for API server tests

### DIFF
--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -64,7 +64,8 @@ from charms.layer.kubernetes_common import client_crt_path
 from charms.layer.kubernetes_common import client_key_path
 from charms.layer.kubernetes_common import get_unit_number
 
-from charms.layer.nagios import install_nagios_plugin, remove_nagios_plugin
+from charms.layer.nagios import install_nagios_plugin_from_text
+from charms.layer.nagios import remove_nagios_plugin
 
 # Override the default nagios shortname regex to allow periods, which we
 # need because our bin names contain them (e.g. 'snap.foo.daemon'). The
@@ -923,15 +924,14 @@ def initial_nrpe_config():
 def update_nrpe_config():
     services = ['snap.{}.daemon'.format(s) for s in worker_services]
     data = render('nagios_plugin.py', context={'node_name': get_node_name()})
-    plugin_path = install_nagios_plugin('templates/nagios_plugin.py',
-                                        'check_k8s_worker.py',
-                                        data=data)
+    plugin_path = install_nagios_plugin_from_text(data,
+                                                  'check_k8s_worker.py')
     hostname = nrpe.get_nagios_hostname()
     current_unit = nrpe.get_nagios_unit_name()
     nrpe_setup = nrpe.NRPE(hostname=hostname)
     nrpe_setup.add_check("node",
                          "Node registered with API Server",
-                         plugin_path)
+                         str(plugin_path))
     nrpe.add_init_service_checks(nrpe_setup, services, current_unit)
     nrpe_setup.write()
 

--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -64,14 +64,18 @@ from charms.layer.kubernetes_common import client_crt_path
 from charms.layer.kubernetes_common import client_key_path
 from charms.layer.kubernetes_common import get_unit_number
 
+from charms.layer.nagios import install_nagios_plugin, remove_nagios_plugin
+
 # Override the default nagios shortname regex to allow periods, which we
 # need because our bin names contain them (e.g. 'snap.foo.daemon'). The
 # default regex in charmhelpers doesn't allow periods, but nagios itself does.
 nrpe.Check.shortname_re = r'[\.A-Za-z0-9-_]+$'
+nrpe_kubeconfig_path = '/var/lib/nagios/.kube/config'
 
 kubeconfig_path = '/root/cdk/kubeconfig'
 gcp_creds_env_key = 'GOOGLE_APPLICATION_CREDENTIALS'
 snap_resources = ['kubectl', 'kubelet', 'kube-proxy']
+worker_services = ('kubelet', 'kube-proxy')
 checksum_prefix = 'kubernetes-worker.resource-checksums.'
 configure_prefix = 'kubernetes-worker.prev_args.'
 cpu_manager_state = "/var/lib/kubelet/cpu_manager_state"
@@ -127,6 +131,9 @@ def upgrade_charm():
     if is_state('kubernetes-worker.registry.configured'):
         set_state('kubernetes-master-worker-base.registry.configured')
         remove_state('kubernetes-worker.registry.configured')
+
+    if is_flag_set('nrpe-external-master.available'):
+        update_nrpe_config()
 
     remove_state('kubernetes-worker.cni-plugins.installed')
     remove_state('kubernetes-worker.config.created')
@@ -511,6 +518,7 @@ def start_worker():
     restart_unit_services()
     update_kubelet_status()
     set_state('kubernetes-worker.label-config-required')
+    set_state('nrpe-external-master.reconfigure')
     remove_state('kubernetes-worker.restart-needed')
 
 
@@ -900,39 +908,62 @@ def get_kube_api_servers(kube_api):
 
 @when('nrpe-external-master.available')
 @when_not('nrpe-external-master.initial-config')
-def initial_nrpe_config(nagios=None):
+def initial_nrpe_config():
     set_state('nrpe-external-master.initial-config')
-    update_nrpe_config(nagios)
+    update_nrpe_config()
 
 
 @when('kubernetes-worker.config.created')
 @when('nrpe-external-master.available')
+@when('kube-api-endpoint.available')
+@when('kube-control.auth.available')
 @when_any('config.changed.nagios_context',
-          'config.changed.nagios_servicegroups')
-def update_nrpe_config(unused=None):
-    services = ('snap.kubelet.daemon', 'snap.kube-proxy.daemon')
+          'config.changed.nagios_servicegroups',
+          'nrpe-external-master.reconfigure')
+def update_nrpe_config():
+    services = ['snap.{}.daemon'.format(s) for s in worker_services]
+    data = render('nagios_plugin.py', context={'node_name': get_node_name()})
+    plugin_path = install_nagios_plugin('templates/nagios_plugin.py',
+                                        'check_k8s_worker.py',
+                                        data=data)
     hostname = nrpe.get_nagios_hostname()
     current_unit = nrpe.get_nagios_unit_name()
     nrpe_setup = nrpe.NRPE(hostname=hostname)
+    nrpe_setup.add_check("node",
+                         "Node registered with API Server",
+                         plugin_path)
     nrpe.add_init_service_checks(nrpe_setup, services, current_unit)
     nrpe_setup.write()
+
+    creds = db.get('credentials')
+    if creds:
+        kube_api = endpoint_from_flag('kube-api-endpoint.available')
+        servers = get_kube_api_servers(kube_api)
+        server = servers[get_unit_number() % len(servers)]
+        create_kubeconfig(nrpe_kubeconfig_path, server, ca_crt_path,
+                          token=creds['client_token'], user='nagios')
+        # Make the config dir owned by the nagios user.
+        cmd = ['chown', '-R', 'nagios:nagios',
+               os.path.dirname(nrpe_kubeconfig_path)]
+        check_call(cmd)
+
+    remove_state('nrpe-external-master.reconfigure')
 
 
 @when_not('nrpe-external-master.available')
 @when('nrpe-external-master.initial-config')
-def remove_nrpe_config(nagios=None):
+def remove_nrpe_config():
     remove_state('nrpe-external-master.initial-config')
-
-    # List of systemd services for which the checks will be removed
-    services = ('snap.kubelet.daemon', 'snap.kube-proxy.daemon')
+    remove_nagios_plugin('check_k8s_worker.py')
 
     # The current nrpe-external-master interface doesn't handle a lot of logic,
     # use the charm-helpers code for now.
     hostname = nrpe.get_nagios_hostname()
     nrpe_setup = nrpe.NRPE(hostname=hostname)
 
-    for service in services:
+    for service in worker_services:
         nrpe_setup.remove_check(shortname=service)
+    nrpe_setup.remove_check('node')
 
 
 @when('nvidia.ready')

--- a/templates/nagios_plugin.py
+++ b/templates/nagios_plugin.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2019 Canonical Ltd.
+
+import nagios_plugin3
+import yaml
+from subprocess import check_output
+
+snap_resources = ['kubectl', 'kubelet', 'kube-proxy']
+
+
+def check_snaps_installed():
+    """Confirm the snaps are installed, raise an error if not"""
+    for snap_name in snap_resources:
+        cmd = ['snap', 'list', snap_name]
+        try:
+            check_output(cmd).decode('UTF-8')
+        except Exception:
+            msg = '{} snap is not installed'.format(snap_name)
+            raise nagios_plugin3.CriticalError(msg)
+
+
+def check_node(node):
+    checks = [{'name': 'MemoryPressure',
+               'expected': 'False',
+               'type': 'warn',
+               'error': 'Memory Pressure'},
+              {'name': 'DiskPressure',
+               'expected': 'False',
+               'type': 'warn',
+               'error': 'Disk Pressure'},
+              {'name': 'PIDPressure',
+               'expected': 'False',
+               'type': 'warn',
+               'error': 'PID Pressure'},
+              {'name': 'Ready',
+               'expected': 'True',
+               'type': 'error',
+               'error': 'Node Not Ready'}]
+    msg = []
+    error = False
+    for check in checks:
+        # find the status that matches
+        for s in node['status']['conditions']:
+            if s['type'] == check['name']:
+                # does it match expectations? If not, toss it on the list
+                # of errors so we don't show the first issue, but all.
+                if s['status'].lower() != check['expected'].lower():
+                    msg.append(check['error'])
+                    if check['type'] == 'error':
+                        error = True
+                else:
+                    break
+        else:
+            err_msg = 'Unable to find status for {}'.format(check['error'])
+            raise nagios_plugin3.CriticalError(err_msg)
+
+    if msg:
+        if error:
+            raise nagios_plugin3.CriticalError(msg)
+        else:
+            raise nagios_plugin3.WarnError(msg)
+
+
+def verify_node_registered_and_ready():
+    try:
+        cmd = "/snap/bin/kubectl --kubeconfig /var/lib/nagios/.kube/config" \
+              " get no -o=yaml"
+        y = yaml.load(check_output(cmd.split()))
+    except Exception:
+        raise nagios_plugin3.CriticalError("Unable to run kubectl "
+                                           "and parse output")
+    for node in y['items']:
+        if node['metadata']['name'] == '{{node_name}}':
+            check_node(node)
+            return
+    else:
+        raise nagios_plugin3.CriticalError("Unable to find "
+                                           "node registered on API server")
+
+
+def main():
+    nagios_plugin3.try_check(check_snaps_installed)
+    nagios_plugin3.try_check(verify_node_registered_and_ready)
+    print("OK - No memory, disk, or PID pressure. Registered with API server")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Verifies that the node is registered with the API server.
Verifies snaps are installed
Reports disk, pid, or memory pressure that will keep workloads from being assigned. These are warnings.
Reports node not registered as a critical error

Fixes https://bugs.launchpad.net/charm-kubernetes-worker/+bug/1831943

Tested by intentionally breaking the worker in different ways. Did not test the pressure checks, but it is reading the output from kubectl get no, so assuming the pressure checks are operational.

Depends on: https://github.com/charmed-kubernetes/layer-nagios/pull/1