### PR TITLE
Add support for CoreDNS K8S Charm

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -9,6 +9,7 @@ includes:
   - 'layer:tls-client'
   - 'layer:cdk-service-kicker'
   - 'layer:kubernetes-master-worker-base'
+  - 'interface:coredns'
   - 'interface:http'
   - 'interface:kubernetes-cni'
   - 'interface:kube-dns'

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -33,6 +33,8 @@ requires:
     interface: kube-control
   aws:
     interface: aws-integration
+  coredns:
+    interface: coredns
   gcp:
     interface: gcp-integration
   openstack:


### PR DESCRIPTION
This will add support for using the CoreDNS k8s charm instead of
the cdk-addons snap. The ClusterDNS will be automatically configured
using cross-model-relations.