### PR TITLE
deprecate the registry action

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -32,7 +32,9 @@ microbot:
 upgrade:
     description: Upgrade the kubernetes snaps
 registry:
-     description: Create a private Docker registry
+     description: |
+       Create a private Docker registry.
+       DEPRECATED: See https://ubuntu.com/kubernetes/docs/docker-registry
      params:
       htpasswd:
         type: string

--- a/actions/registry
+++ b/actions/registry
@@ -37,6 +37,13 @@ context = {}
 arch = check_output(['dpkg', '--print-architecture']).rstrip()
 context['arch'] = arch.decode('utf-8')
 
+# This action was deprecated in 1.17.
+action_set({
+    'notice':
+    ('DEPRECATED: See https://ubuntu.com/kubernetes/docs/docker-registry '
+     'for supported container registry options.')
+})
+
 # These config options must be defined in the case of a creation
 param_error = False
 for param in ('tlscert', 'tlskey', 'domain', 'htpasswd', 'htpasswd-plain'):


### PR DESCRIPTION
We support custom container registries via the docker-registry charm.  Deprecate the in-cluster registry.

Fixes https://bugs.launchpad.net/charm-kubernetes-worker/+bug/1854969.