### PR TITLE
Add ingress-default-ssl-certificate config options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .tox/
 __pycache__/
 *.pyc
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .tox/
 __pycache__/
 *.pyc
-.idea

--- a/config.yaml
+++ b/config.yaml
@@ -54,6 +54,14 @@ options:
       to attempt auto-retrieval of intermediate certificates.  The default
       (false) is recommended for all production kubernetes installations, and
       any environment which does not have outbound Internet access.
+  ingress-default-ssl-certificate:
+    type: string
+    default: ""
+    description: |
+      Secret containing a SSL certificate to be used by the default HTTPS server
+      (catch-all). Takes the form "namespace/name". If this flag is not provided
+      ingress will use a self-signed certificate.
+      Example: "default/foo-tls"
   nginx-image:
     type: string
     default: "auto"

--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -129,7 +129,7 @@ def upgrade_charm():
 
     # force certs to be updated
     if is_state('certificates.available') and \
-       is_state('kube-control.connected'):
+            is_state('kube-control.connected'):
         send_data()
 
     if is_state('kubernetes-worker.registry.configured'):
@@ -156,7 +156,7 @@ def remove_old_ingress():
         kubectl('delete', 'svc', 'default-http-backend',
                 '--ignore-not-found')
         kubectl('delete', 'ds', 'nginx-ingress-{}-controller'.format(
-                    hookenv.service_name()), '--ignore-not-found')
+            hookenv.service_name()), '--ignore-not-found')
         kubectl('delete', 'serviceaccount',
                 'nginx-ingress-{}-serviceaccount'.format(
                     hookenv.service_name()), '--ignore-not-found')
@@ -405,7 +405,7 @@ def deprecated_extra_args():
     deprecated_args = []
     services = [
         # service       config_key
-        ('kubelet',    'kubelet-extra-args'),
+        ('kubelet', 'kubelet-extra-args'),
         ('kube-proxy', 'proxy-extra-args')
     ]
     for service, config_key in services:
@@ -853,7 +853,7 @@ def render_and_launch_ingress():
 
     context['defaultbackend_image'] = config.get('default-backend-image')
     if (context['defaultbackend_image'] == "" or
-       context['defaultbackend_image'] == "auto"):
+            context['defaultbackend_image'] == "auto"):
         if registry_location:
             backend_registry = registry_location
         else:
@@ -873,6 +873,12 @@ def render_and_launch_ingress():
         'ingress-ssl-chain-completion')
     context['enable_ssl_passthrough'] = config.get(
         'ingress-ssl-passthrough')
+
+    context['default_ssl_certificate'] = ''
+    if config.get('ingress-default-ssl-certificate'):
+        context['default_ssl_certificate'] = '--default-ssl-certificate={}'.format(
+            config.get('ingress-default-ssl-certificate'))
+
     context['ingress_image'] = config.get('nginx-image')
     if context['ingress_image'] == "" or context['ingress_image'] == "auto":
         if registry_location:
@@ -883,7 +889,7 @@ def render_and_launch_ingress():
                   'arm64': 'kubernetes-ingress-controller/nginx-ingress-controller-arm64:0.26.1',  # noqa
                   's390x': 'kubernetes-ingress-controller/nginx-ingress-controller-s390x:0.20.0',  # noqa
                   'ppc64el': 'kubernetes-ingress-controller/nginx-ingress-controller-ppc64le:0.20.0',  # noqa
-                 }
+                  }
         context['ingress_image'] = '{}/{}'.format(nginx_registry,
                                                   images.get(context['arch'],
                                                              images['amd64']))

--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -876,7 +876,7 @@ def render_and_launch_ingress():
 
     context['default_ssl_certificate'] = ''
     if config.get('ingress-default-ssl-certificate'):
-        context['default_ssl_certificate'] = '--default-ssl-certificate={}'.format(
+        context['default_ssl_certificate'] = '- --default-ssl-certificate={}'.format(
             config.get('ingress-default-ssl-certificate'))
 
     context['ingress_image'] = config.get('nginx-image')

--- a/templates/ingress-daemon-set.yaml
+++ b/templates/ingress-daemon-set.yaml
@@ -234,6 +234,7 @@ spec:
             - --annotations-prefix=nginx.ingress.kubernetes.io
             - --enable-ssl-chain-completion={{ ssl_chain_completion }}
             - --enable-ssl-passthrough={{ enable_ssl_passthrough }}
+            {{ default_ssl_certificate }}
           securityContext:
             capabilities:
               drop:


### PR DESCRIPTION
I added the default-ssl-certificate to avoid having to define tls certs in our ingress config maps. This way we can provide a real one (wildcard or otherwise), and have it work out of the box.

Reference documentation:
https://jaas.ai/u/containers/kubernetes-worker/ 
https://kubernetes.github.io/ingress-nginx/user-guide/tls/#default-ssl-certificate
https://kubernetes.github.io/ingress-nginx/user-guide/cli-arguments/