### PR TITLE
Add ingress-default-ssl-certificate config options

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -38,6 +38,22 @@ options:
         --runtime-config=batch/v2alpha1=true --profiling=true
       Note: As of Kubernetes 1.10.x, many of Kubelet's args have been deprecated, and can
       be set with kubelet-extra-config instead.
+  ingress-default-ssl-certificate:
+    type: string
+    default: ""
+    description: |
+      SSL certificate to be used by the default HTTPS server. If one of the
+      flag ingress-default-ssl-certificate or ingress-default-ssl-key is not
+      provided ingress will use a self-signed certificate. This parameter is
+      specific to nginx-ingress-controller.
+  ingress-default-ssl-key:
+    type: string
+    default: ""
+    description: |
+      Private key to be used by the default HTTPS server. If one of the flag
+      ingress-default-ssl-certificate or ingress-default-ssl-key is not
+      provided ingress will use a self-signed certificate. This parameter is
+      specific to nginx-ingress-controller.
   ingress-ssl-passthrough:
     type: boolean
     default: false

--- a/templates/ingress-daemon-set.yaml
+++ b/templates/ingress-daemon-set.yaml
@@ -5,6 +5,23 @@ metadata:
   labels:
     cdk-{{ juju_application }}-ingress: "true"
 
+{%- if default_ssl_certificate_option %}
+---
+kind: Secret
+apiVersion: v1
+type: Opaque
+metadata:
+  name: default-ssl-certificate
+  namespace: ingress-nginx-{{ juju_application }}
+  labels:
+    app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
+    app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
+    cdk-{{ juju_application }}-ingress: "true"
+data:
+  tls.crt: {{ default_ssl_certificate }}
+  tls.key: {{ default_ssl_key }}
+{%- endif %}
+
 ---
 kind: ConfigMap
 apiVersion: v1
@@ -234,6 +251,9 @@ spec:
             - --annotations-prefix=nginx.ingress.kubernetes.io
             - --enable-ssl-chain-completion={{ ssl_chain_completion }}
             - --enable-ssl-passthrough={{ enable_ssl_passthrough }}
+{%- if default_ssl_certificate_option %}
+            {{ default_ssl_certificate_option }}
+{%- endif %}
           securityContext:
             capabilities:
               drop:


### PR DESCRIPTION
Introduces new configuration options default-ssl-certificate
and default-ssl-key to the charm. This will allow to modify
the default ssl certificate used by the ingress controller.