### PR TITLE
Add support for multiple CNI subordinates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
   - "3.5"
+  - "3.6"
+  - "3.7"
 install:
   - pip install tox-travis
 script:

--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -1397,6 +1397,17 @@ def get_registry_location():
 
 
 def configure_default_cni():
+    """Set the default CNI configuration to be used by CNI clients
+    (kubelet, containerd).
+
+    CNI clients choose whichever CNI config in /etc/cni/net.d/ is
+    alphabetically first, so we accomplish this by creating a file named
+    /etc/cni/net.d/05-default.conflist, which is alphabetically earlier than
+    typical CNI config names, e.g. 10-flannel.conflist and 10-calico.conflist
+
+    The created 05-default.conflist file is a symlink to whichever CNI config
+    is actually going to be used.
+    """
     # Clean up current default
     cni_conf_dir = '/etc/cni/net.d'
     for filename in os.listdir(cni_conf_dir):

--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -1408,7 +1408,6 @@ def configure_default_cni():
     default_cni = kube_control.get_default_cni()
     cni = endpoint_from_flag('cni.available')
     cni_conf = cni.get_config(default=default_cni)
-    cni_conf_file = cni_conf['cni-conf-file']
-    source = cni_conf_dir + '/' + cni_conf_file
+    source = cni_conf['cni-conf-file']
     dest = cni_conf_dir + '/' + '05-default.' + source.split('.')[-1]
     os.symlink(source, dest)

--- a/tests/test_kubernetes_worker.py
+++ b/tests/test_kubernetes_worker.py
@@ -27,6 +27,6 @@ def test_configure_default_cni(os_symlink, os_remove, os_listdir):
     kubernetes_worker.configure_default_cni()
     os_remove.assert_called_once_with('/etc/cni/net.d/05-default.conflist')
     os_symlink.assert_called_once_with(
-        '/etc/cni/net.d/10-cni.conflist',
+        '10-cni.conflist',
         '/etc/cni/net.d/05-default.conflist'
     )

--- a/tests/test_kubernetes_worker.py
+++ b/tests/test_kubernetes_worker.py
@@ -1,17 +1,32 @@
 import pytest
-from unittest import mock
+from unittest.mock import patch
+from reactive import kubernetes_worker
+from charms.reactive import endpoint_from_flag
 
 
 def patch_fixture(patch_target):
     @pytest.fixture()
     def _fixture():
-        with mock.patch(patch_target) as m:
+        with patch(patch_target) as m:
             yield m
     return _fixture
 
 
-def test_imports():
-    # dummy test to just make sure files import properly
-    # replace with real tests later
-    from reactive import kubernetes_worker as handlers
-    assert handlers
+@patch('os.listdir')
+@patch('os.remove')
+@patch('os.symlink')
+def test_configure_default_cni(os_symlink, os_remove, os_listdir):
+    os_listdir.return_value = ['05-default.conflist', '10-cni.conflist']
+    kube_control = endpoint_from_flag('kube-control.default_cni.available')
+    kube_control.get_default_cni.return_value = 'test-cni'
+    cni = endpoint_from_flag('cni.available')
+    cni.get_config.return_value = {
+        'cidr': '192.168.0.0/24',
+        'cni-conf-file': '10-cni.conflist'
+    }
+    kubernetes_worker.configure_default_cni()
+    os_remove.assert_called_once_with('/etc/cni/net.d/05-default.conflist')
+    os_symlink.assert_called_once_with(
+        '/etc/cni/net.d/10-cni.conflist',
+        '/etc/cni/net.d/05-default.conflist'
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,8 @@ envlist = lint,py3
 
 [tox:travis]
 3.5: lint,py3
+3.6: lint,py3
+3.7: lint,py3
 
 [testenv]
 basepython = python3


### PR DESCRIPTION
Partial fix for https://bugs.launchpad.net/charm-kubernetes-master/+bug/1861709

Please be careful merging this, as it's mutually dependent on the work of other PRs in that issue. They will need to be merged together.

This updates kubernetes-worker to fetch default-cni from the kube-control relation. It is used both to configure kube-proxy, and to create a symlink in /etc/cni/net.d/ to control which CNI config file is used by containerd/kubelet.