### PR TITLE
bump pause and ingress images

### DIFF
--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -807,11 +807,11 @@ def configure_kubelet(dns, ingress_ip):
 
     # If present, ensure kubelet gets the pause container from the configured
     # registry. When not present, kubelet uses a default image location
-    # (currently k8s.gcr.io/pause:3.1).
+    # (currently k8s.gcr.io/pause:3.2).
     registry_location = get_registry_location()
     if registry_location:
         kubelet_opts['pod-infra-container-image'] = \
-            '{}/pause-{}:3.1'.format(registry_location, arch())
+            '{}/pause-{}:3.2'.format(registry_location, arch())
 
     configure_kubernetes_service(configure_prefix, 'kubelet', kubelet_opts,
                                  'kubelet-extra-args')
@@ -898,8 +898,8 @@ def render_and_launch_ingress():
             nginx_registry = registry_location
         else:
             nginx_registry = 'quay.io'
-        images = {'amd64': 'kubernetes-ingress-controller/nginx-ingress-controller-amd64:0.26.1',  # noqa
-                  'arm64': 'kubernetes-ingress-controller/nginx-ingress-controller-arm64:0.26.1',  # noqa
+        images = {'amd64': 'kubernetes-ingress-controller/nginx-ingress-controller-amd64:0.30.0',  # noqa
+                  'arm64': 'kubernetes-ingress-controller/nginx-ingress-controller-arm64:0.30.0',  # noqa
                   's390x': 'kubernetes-ingress-controller/nginx-ingress-controller-s390x:0.20.0',  # noqa
                   'ppc64el': 'kubernetes-ingress-controller/nginx-ingress-controller-ppc64le:0.20.0',  # noqa
                  }
@@ -1381,7 +1381,7 @@ def update_registry_location():
         runtime = endpoint_from_flag('endpoint.container-runtime.available')
         if runtime:
             # Construct and send the sandbox image (pause container) to our runtime
-            uri = '{}/pause-{}:3.1'.format(registry_location, arch())
+            uri = '{}/pause-{}:3.2'.format(registry_location, arch())
             runtime.set_config(
                 sandbox_image=uri
             )

--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -903,6 +903,12 @@ def render_and_launch_ingress():
                   's390x': 'kubernetes-ingress-controller/nginx-ingress-controller-s390x:0.20.0',  # noqa
                   'ppc64el': 'kubernetes-ingress-controller/nginx-ingress-controller-ppc64le:0.20.0',  # noqa
                  }
+        # NB: ingress >= 0.27 switched to alpine, where www-data uid is now 101
+        # https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.27.0
+        if context['arch'] == 'amd64' or context['arch'] == 'arm64':
+            context['ingress_uid'] = '101'
+        else:
+            context['ingress_uid'] = '33'
         context['ingress_image'] = '{}/{}'.format(nginx_registry,
                                                   images.get(context['arch'],
                                                              images['amd64']))

--- a/templates/ingress-daemon-set.yaml
+++ b/templates/ingress-daemon-set.yaml
@@ -260,8 +260,7 @@ spec:
                 - ALL
               add:
                 - NET_BIND_SERVICE
-            # www-data -> 33
-            runAsUser: 33
+            runAsUser: {{ ingress_uid }}
           env:
             - name: POD_NAME
               valueFrom:


### PR DESCRIPTION
https://bugs.launchpad.net/charm-kubernetes-worker/+bug/1862236

update pause and ingress images to the latest current versions in preparation for 1.18.

This depends on the images being uploaded to rocks, which means https://github.com/charmed-kubernetes/bundle/pull/767 needs to be merged and a new cdk-addons 1.18 job needs to be run prior to merging this.

Note: latest available s390x and ppc64le images are still at 0.20.0.