### PR TITLE
Fix upgrade issues introduced by multiple CNI changes

### DIFF
--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -137,6 +137,20 @@ def upgrade_charm():
         set_state('kubernetes-master-worker-base.registry.configured')
         remove_state('kubernetes-worker.registry.configured')
 
+    # need to clear cni.available state if it's no longer accurate
+    if is_state('cni.available'):
+        cni = endpoint_from_flag('cni.available')
+        if not cni.config_available():
+            hookenv.log('cni.config_available() is False, clearing'
+                        + ' cni.available flag')
+            remove_state('cni.available')
+
+    # need to bump the kube-control relation in case
+    # kube-control.default_cni.available is not set when it should be
+    if is_state('kube-control.connected'):
+        kube_control = endpoint_from_flag('kube-control.connected')
+        kube_control.manage_flags()
+
     remove_state('kubernetes-worker.cni-plugins.installed')
     remove_state('kubernetes-worker.config.created')
     remove_state('kubernetes-worker.ingress.available')


### PR DESCRIPTION
Partial fix for https://bugs.launchpad.net/bugs/1861709

This fixes a couple upgrade issues introduced by https://github.com/charmed-kubernetes/charm-kubernetes-worker/pull/50:

1. Upgrading the charm from current stable to edge produces a hook error:

```
unit-kubernetes-worker-0: 16:44:57 ERROR unit.kubernetes-worker/0.juju-log kube-control:6: Hook error:
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-kubernetes-worker-0/.venv/lib/python3.6/site-packages/charms/reactive/__init__.py", line 74, in main
    bus.dispatch(restricted=restricted_mode)
  File "/var/lib/juju/agents/unit-kubernetes-worker-0/.venv/lib/python3.6/site-packages/charms/reactive/bus.py", line 390, in dispatch
    _invoke(other_handlers)
  File "/var/lib/juju/agents/unit-kubernetes-worker-0/.venv/lib/python3.6/site-packages/charms/reactive/bus.py", line 359, in _invoke
    handler.invoke()
  File "/var/lib/juju/agents/unit-kubernetes-worker-0/.venv/lib/python3.6/site-packages/charms/reactive/bus.py", line 181, in invoke
    self._action(*args)
  File "/var/lib/juju/agents/unit-kubernetes-worker-0/charm/reactive/kubernetes_worker.py", line 569, in start_worker
    configure_default_cni()
  File "/var/lib/juju/agents/unit-kubernetes-worker-0/charm/reactive/kubernetes_worker.py", line 1439, in configure_default_cni
    dest = cni_conf_dir + '/' + '05-default.' + source.split('.')[-1]
AttributeError: 'NoneType' object has no attribute 'split'
```

This occurs because the `cni.available` flag is set prior to the upgrade, and stays set after the upgrade, even though `cni-conf-file` is missing from the CNI config. The fix is to manually clear the `cni.available` flag during the upgrade-charm hook.

2. `start_worker` handler never runs after the upgrade.

This happens if kubernetes-master sends the default-cni to kubernetes-worker before kubernetes-worker is upgraded. If kubernetes-worker is upgraded later, then no `kube-control-relation-changed` hook will fire. The kube-control endpoint's `manage_flags()` method will never be called, so the flags will be incorrect.

The fix is to manually call the kube-control endpoint's `manage_flags()` method during upgrade-charm.