### PR TITLE
Adds the ingress-use-forwaded-headers config option.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -70,6 +70,21 @@ options:
       to attempt auto-retrieval of intermediate certificates.  The default
       (false) is recommended for all production kubernetes installations, and
       any environment which does not have outbound Internet access.
+  ingress-use-forwarded-headers:
+    type: boolean
+    default: false
+    description: |
+      If true, NGINX passes the incoming X-Forwarded-* headers to upstreams. Use this
+      option when NGINX is behind another L7 proxy / load balancer that is setting
+      these headers.
+
+      If false, NGINX ignores incoming X-Forwarded-* headers, filling them with the
+      request information it sees. Use this option if NGINX is exposed directly to
+      the internet, or it's behind a L3/packet-based load balancer that doesn't alter
+      the source IP in the packets.
+
+      Reference: https://github.com/kubernetes/ingress-nginx/blob/a9c706be12a8be418c49ab1f60a02f52f9b14e55/
+      docs/user-guide/nginx-configuration/configmap.md#use-forwarded-headers.
   nginx-image:
     type: string
     default: "auto"

--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -937,6 +937,9 @@ def render_and_launch_ingress():
     else:
         context['daemonset_api_version'] = 'apps/v1'
         context['deployment_api_version'] = 'apps/v1'
+    context['use_forwarded_headers'] = "true" if config.get(
+        "ingress-use-forwarded-headers") else "false"
+
     manifest = addon_path.format('ingress-daemon-set.yaml')
     render('ingress-daemon-set.yaml', manifest, context)
     hookenv.log('Creating the ingress daemon set.')

--- a/templates/ingress-daemon-set.yaml
+++ b/templates/ingress-daemon-set.yaml
@@ -32,6 +32,8 @@ metadata:
     app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
     app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
     cdk-{{ juju_application }}-ingress: "true"
+data:
+  use-forwarded-headers: "{{ use_forwarded_headers }}"
 
 ---
 kind: ConfigMap


### PR DESCRIPTION
* Modify config.yaml to add a new configuration directive
'ingress-use-forwaded-headers'.

* Modify the ctxt configuration for the daemonset to check
if the config option is set.

* Modify the ingress-daemon-set.yaml template to pass the
use-forwarded-headers data ConfigMap.

Fixes: #1842286

Signed-off-by: Jorge Niedbalski <jorge.niedbalski@canonical.com>