### PR TITLE
Increase nginx-ingress-controller to 0.31.1

### DIFF
--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -938,8 +938,8 @@ def render_and_launch_ingress():
             nginx_registry = registry_location
         else:
             nginx_registry = 'quay.io'
-        images = {'amd64': 'kubernetes-ingress-controller/nginx-ingress-controller-amd64:0.30.0',  # noqa
-                  'arm64': 'kubernetes-ingress-controller/nginx-ingress-controller-arm64:0.30.0',  # noqa
+        images = {'amd64': 'kubernetes-ingress-controller/nginx-ingress-controller-amd64:0.31.1',  # noqa
+                  'arm64': 'kubernetes-ingress-controller/nginx-ingress-controller-arm64:0.31.1',  # noqa
                   's390x': 'kubernetes-ingress-controller/nginx-ingress-controller-s390x:0.20.0',  # noqa
                   'ppc64el': 'kubernetes-ingress-controller/nginx-ingress-controller-ppc64le:0.20.0',  # noqa
                  }


### PR DESCRIPTION
Increases nginx-ingress version to 0.31.1

This commit increases 0.31.1 as indicated in
LP: https://bugs.launchpad.net/charm-kubernetes-worker/+bug/1876724

Signed-off-by: Jorge Niedbalski <jorge.niedbalski@canonical.com>