### PR TITLE
Add http provides endpoint.

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -48,6 +48,8 @@ provides:
   cni:
     interface: kubernetes-cni
     scope: container
+  website:
+    interface: http
 resources:
   cni-amd64:
     type: file

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -48,7 +48,7 @@ provides:
   cni:
     interface: kubernetes-cni
     scope: container
-  website:
+  ingress-proxy:
     interface: http
 resources:
   cni-amd64:

--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -1488,7 +1488,7 @@ def configure_default_cni():
     dest = cni_conf_dir + '/' + '05-default.' + source.split('.')[-1]
     os.symlink(source, dest)
 
+
 @when('ingress-proxy.available')
 def configure_ingress_proxy(ingress_proxy):
     ingress_proxy.configure(port='80')
-

--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -1488,6 +1488,7 @@ def configure_default_cni():
     dest = cni_conf_dir + '/' + '05-default.' + source.split('.')[-1]
     os.symlink(source, dest)
 
-@when('website.available')
-def configure_website(website):
-    website.configure(port='80')
+@when('ingress-proxy.available')
+def configure_ingress_proxy(ingress_proxy):
+    ingress_proxy.configure(port='80')
+

--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -1487,3 +1487,7 @@ def configure_default_cni():
     source = cni_conf['cni-conf-file']
     dest = cni_conf_dir + '/' + '05-default.' + source.split('.')[-1]
     os.symlink(source, dest)
+
+@when('website.available')
+def configure_website(website):
+    website.configure(port='80')


### PR DESCRIPTION
Adding website http endpoint of provides type will allow to relate for example apache2 as frontend http server to kubernetes-worker. Apache than acts as reverse proxy/load balancer that forwards request through ingress controller to Kubernetes cluster. It allows to provide single access point for Kubernetes applications with automatic balancer configuration.  The balancer configuration will be automatically changed after Kubernetes worker scaling.

Fixes: https://bugs.launchpad.net/charm-kubernetes-worker/+bug/1868690