### PR TITLE
Fix vSphere host UUID discovery

### DIFF
--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -67,6 +67,7 @@ from charms.layer.kubernetes_common import server_key_path
 from charms.layer.kubernetes_common import client_crt_path
 from charms.layer.kubernetes_common import client_key_path
 from charms.layer.kubernetes_common import get_unit_number
+from charms.layer.kubernetes_common import _get_vmware_uuid
 
 from charms.layer.nagios import install_nagios_plugin_from_text
 from charms.layer.nagios import remove_nagios_plugin
@@ -779,9 +780,7 @@ def configure_kubelet(dns, ingress_ip):
         # vsphere just needs to be joined on the worker (vs 'ready')
         kubelet_opts['cloud-provider'] = 'vsphere'
         # NB: vsphere maps node product-id to its uuid (no config file needed).
-        uuid_file = '/sys/class/dmi/id/product_uuid'
-        with open(uuid_file, 'r') as f:
-            uuid = f.read().strip()
+        uuid = _get_vmware_uuid()
         kubelet_opts['provider-id'] = 'vsphere://{}'.format(uuid)
     elif is_state('endpoint.azure.ready'):
         azure = endpoint_from_flag('endpoint.azure.ready')


### PR DESCRIPTION
When upgrading the vSphere hardware from 5.5 -> 6.5 no more PVCs
can be created. This happens because of a bug on the SEABIOS virtual
hardware that swap the endianness of the content of '/sys/class/dmi/id/product_uuid'
on the new virtual hardware versions and now it differs from
'/sys/class/dmi/id/product_serial'.
So, the content in product_uuid is: F5132842-20D4-6171-5DB0-7B96440CCF54
While the product_serial (actually correct and understood by vSphere API)
is:422813f5-d420-7161-5db0-7b96440ccf54

So, we need to use the product_serial instead of product_uuid