### PR TITLE
update microbot action

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -21,14 +21,18 @@ resume:
 microbot:
     description: Launch microbot containers
     params:
-      replicas:
-        type: integer
-        default: 3
-        description: Number of microbots to launch in Kubernetes.
       delete:
         type: boolean
         default: False
         description: Remove a microbots deployment, service, and ingress if True.
+      registry:
+        type: string
+        default: rocks.canonical.com:443/cdk
+        description: Registry to use for the microbot image.
+      replicas:
+        type: integer
+        default: 3
+        description: Number of microbots to launch in Kubernetes.
 upgrade:
     description: Upgrade the kubernetes snaps
 registry:

--- a/actions/microbot
+++ b/actions/microbot
@@ -17,8 +17,7 @@
 import os
 import sys
 
-from charmhelpers.core.hookenv import action_get
-from charmhelpers.core.hookenv import action_set
+from charmhelpers.core.hookenv import action_fail, action_get, action_set
 from charmhelpers.core.hookenv import unit_public_ip
 from charms.reactive import endpoint_from_flag
 from charms.templating.jinja2 import render
@@ -27,9 +26,10 @@ from subprocess import call, check_output
 os.environ['PATH'] += os.pathsep + os.path.join(os.sep, 'snap', 'bin')
 
 context = {}
-context['replicas'] = action_get('replicas')
 context['delete'] = action_get('delete')
 context['public_address'] = unit_public_ip()
+context['registry'] = action_get('registry')
+context['replicas'] = action_get('replicas')
 
 arch = check_output(['dpkg', '--print-architecture']).rstrip()
 context['arch'] = arch.decode('utf-8')
@@ -69,7 +69,7 @@ if kube_control:
 render('microbot-example.yaml', '/root/cdk/addons/microbot.yaml',
        context)
 
-create_command = kubectl + ['create', '-f',
+create_command = kubectl + ['apply', '-f',
                             '/root/cdk/addons/microbot.yaml']
 
 create_response = call(create_command)
@@ -78,4 +78,4 @@ if create_response == 0:
     action_set({'address':
                'microbot.{}.nip.io'.format(context['public_address'])})
 else:
-    action_set({'microbot-create': 'Failed microbot creation.'})
+    action_fail('Failed to apply microbot manifest.')

--- a/templates/microbot-example.yaml
+++ b/templates/microbot-example.yaml
@@ -48,7 +48,7 @@ spec:
   selector:
     app: microbot
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
  name: microbot-ingress
@@ -58,6 +58,9 @@ spec:
      http:
        paths:
          - path: /
+           pathType: Prefix
            backend:
-             serviceName: microbot
-             servicePort: 80
+             service:
+               name: microbot
+               port:
+                number: 80


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/charm-kubernetes-worker/+bug/1906722

- make image registry configurable (default to rocks.c.c)
- use [latest ingress api version](https://kubernetes.io/docs/concepts/services-networking/ingress/)
  - switch 'kubectl create' to 'apply' so a prior manifest can be updated without needing to delete first.