### PR TITLE
Fix failure to build cni

### DIFF
--- a/build-cni-resources.sh
+++ b/build-cni-resources.sh
@@ -26,7 +26,7 @@ mkdir "$temp_dir"
       -e GOOS=linux \
       -e GOARCH="$arch" \
       -v "$temp_dir"/cni-plugins:/cni \
-      golang \
+      golang:1.15 \
       /bin/bash -c "cd /cni && ./build.sh && chown -R ${USER_ID}:${GROUP_ID} /cni"
 
     (cd cni-plugins/bin


### PR DESCRIPTION
Fixes

```
16:00:45 [kubernetes-worker] Building cni v0.7.5 for amd64
16:00:45 [kubernetes-worker] + rm -f 'cni-plugins/bin/*'
16:00:45 [kubernetes-worker] + docker run --rm -e GOOS=linux -e GOARCH=amd64 -v /var/lib/jenkins/slaves/jenkins-slave-7/workspace/build-charms/.cache/charmbuild/jenkins-build-charms-1002/charms/kubernetes-worker/tmp/build-cni-resources.tmp/cni-plugins:/cni golang /bin/bash -c 'cd /cni && ./build.sh && chown -R 999:999 /cni'
16:00:45 [kubernetes-worker] Building plugins
16:00:45 [kubernetes-worker] flannel
16:00:45 [kubernetes-worker] no required module provides package github.com/containernetworking/plugins/plugins/meta/flannel: working directory is not part of a module
16:00:46 [kubernetes-worker] Stopping
16:00:46 Failed to build custom resources
```

by pinning to golang 1.15.