### PR TITLE
Report when waiting on cluster auth

### DIFF
--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -439,6 +439,9 @@ def charm_status():
     if is_state('kubernetes-worker.cohorts.failed'):
         hookenv.status_set('waiting',
                            'Failed to join snap cohorts (see logs), will retry.')
+    if not is_state('kube-control.auth.available'):
+        hookenv.status_set('waiting', 'Waiting for cluster credentials.')
+        return
     if not is_state('kube-control.dns.available'):
         # During deployment the worker has to start kubelet without cluster dns
         # configured. If this is the first unit online in a service pool


### PR DESCRIPTION
If the worker is waiting on cluster auth info from the master, it currently reports it as "Waiting for kube-proxy to start." This doesn't
indicate why the kube-proxy hasn't started, nor convey that it will not, in fact, ever start unless the worker receives the cluster auth info.

Part of [lp:1916780][]

[lp:1916780]: https://bugs.launchpad.net/charm-kubernetes-worker/+bug/1916780