### PR TITLE
Bump k8s snap channel to 1.21

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -22,7 +22,7 @@ options:
       This option is now deprecated and has no effect.
   channel:
     type: string
-    default: "1.20/stable"
+    default: "1.21/stable"
     description: |
       Snap channel to install Kubernetes worker services from
   require-manual-upgrade:


### PR DESCRIPTION
For the CK 1.21 RC release. The stable branches have already been reset to master, therefore, this PR is targeted against stable.