### PR TITLE
Bump default channel to 1.22/edge

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -22,7 +22,7 @@ options:
       This option is now deprecated and has no effect.
   channel:
     type: string
-    default: "1.20/stable"
+    default: "1.22/edge"
     description: |
       Snap channel to install Kubernetes worker services from
   require-manual-upgrade:


### PR DESCRIPTION
1.21 is now stable.  Edge builds from `master` branch should move up to 1.22.