### PR TITLE
bump ingress to 0.45.0

### DIFF
--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -999,7 +999,7 @@ def render_and_launch_ingress():
             context['ingress_uid'] = '101'
             context['ingress_image'] = '/'.join([
                 registry_location or 'us.gcr.io',
-                'k8s-artifacts-prod/ingress-nginx/controller:v0.44.0',
+                'k8s-artifacts-prod/ingress-nginx/controller:v0.45.0',
             ])
 
     kubelet_version = get_version('kubelet')


### PR DESCRIPTION
This bumps the nginx ingress image to 0.45.0 to address an openssl cve.

Partial fix for https://bugs.launchpad.net/charm-kubernetes-worker/+bug/1925371; the other piece comes in getting the new image to rocks, which happened in https://github.com/charmed-kubernetes/bundle/pull/798.