### PR TITLE
Break if the condition is found, regardless of its status

### DIFF
--- a/templates/nagios_plugin.py
+++ b/templates/nagios_plugin.py
@@ -51,8 +51,7 @@ def check_node(node):
                     msg.append(check['error'])
                     if check['type'] == 'error':
                         error = True
-                else:
-                    break
+                break
         else:
             err_msg = 'Unable to find status for {}'.format(check['error'])
             raise nagios_plugin3.CriticalError(err_msg)


### PR DESCRIPTION
Break misplaced was causing the wrong message to be printed when an expectation was not met, and also to stop cycling through the rest of the conditions.