### PR TITLE
stop unconfining in the lxd profile

### DIFF
--- a/lxd-profile.yaml
+++ b/lxd-profile.yaml
@@ -2,7 +2,6 @@ name: juju-default-k8s-deployment-0
 config:
   linux.kernel_modules: ip_tables,ip6_tables,netlink_diag,nf_nat,overlay
   raw.lxc: |
-    lxc.apparmor.profile=unconfined
     lxc.mount.auto=proc:rw sys:rw
     lxc.cgroup.devices.allow=a
     lxc.cap.drop=


### PR DESCRIPTION
Remove `lxc.apparmor.profile=unconfined` from `lxd-profile.yaml`.

See commentary/tests in https://github.com/charmed-kubernetes/charm-kubernetes-master/pull/168. The same applies here.

Fixes [LP 1907153](https://bugs.launchpad.net/snapd/+bug/1907153).