### PR TITLE
Fix nginx-ingress-controller on k8s 1.22

### DIFF
--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -999,7 +999,7 @@ def render_and_launch_ingress():
             context['ingress_uid'] = '101'
             context['ingress_image'] = '/'.join([
                 registry_location or 'us.gcr.io',
-                'k8s-artifacts-prod/ingress-nginx/controller:v0.45.0',
+                'k8s-artifacts-prod/ingress-nginx/controller:v1.0.0-beta.1',
             ])
 
     kubelet_version = get_version('kubelet')

--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -999,7 +999,7 @@ def render_and_launch_ingress():
             context['ingress_uid'] = '101'
             context['ingress_image'] = '/'.join([
                 registry_location or 'us.gcr.io',
-                'k8s-artifacts-prod/ingress-nginx/controller:v1.0.0-beta.1',
+                'k8s-artifacts-prod/ingress-nginx/controller:v1.0.0-beta.3',
             ])
 
     kubelet_version = get_version('kubelet')

--- a/templates/ingress-daemon-set.yaml
+++ b/templates/ingress-daemon-set.yaml
@@ -104,15 +104,8 @@ rules:
       - list
       - watch
   - apiGroups:
-      - ""
-    resources:
-      - events
-    verbs:
-      - create
-      - patch
-  - apiGroups:
-      - "extensions"
-      - "networking.k8s.io"
+      - extensions
+      - "networking.k8s.io" # # k8s 1.14+
     resources:
       - ingresses
     verbs:
@@ -120,12 +113,27 @@ rules:
       - list
       - watch
   - apiGroups:
-      - "extensions"
-      - "networking.k8s.io"
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - extensions
+      - "networking.k8s.io" # k8s 1.14+
     resources:
       - ingresses/status
     verbs:
       - update
+  - apiGroups:
+      - "networking.k8s.io" # k8s 1.14+
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -140,9 +148,6 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - configmaps
-      - pods
-      - secrets
       - namespaces
     verbs:
       - get
@@ -150,12 +155,51 @@ rules:
       - ""
     resources:
       - configmaps
+      - pods
+      - secrets
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+      - "networking.k8s.io" # k8s 1.14+
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+      - "networking.k8s.io" # k8s 1.14+
+    resources:
+      - ingresses/status
+    verbs:
+      - update
+  - apiGroups:
+      - "networking.k8s.io" # k8s 1.14+
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
     resourceNames:
-      # Defaults to "<election-id>-<ingress-class>"
-      # Here: "<ingress-controller-leader>-<nginx>"
-      # This has to be adapted if you change either parameter
-      # when launching the nginx-ingress-controller.
-      - "ingress-controller-leader-nginx"
+      - ingress-controller-leader
+    resources:
+      - configmaps
     verbs:
       - get
       - update
@@ -168,10 +212,10 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - endpoints
+      - events
     verbs:
-      - get
-
+      - create
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -298,3 +342,15 @@ spec:
             timeoutSeconds: 1
 
 ---
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  labels:
+    app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
+    app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
+    cdk-{{ juju_application }}-ingress: "true"
+  name: nginx-ingress-controller
+  annotations:
+    ingressclass.kubernetes.io/is-default-class: "true"
+spec:
+  controller: k8s.io/ingress-nginx

--- a/templates/ingress-daemon-set.yaml
+++ b/templates/ingress-daemon-set.yaml
@@ -69,7 +69,7 @@ metadata:
     cdk-{{ juju_application }}-ingress: "true"
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: nginx-ingress-clusterrole-{{ juju_application }}
@@ -127,7 +127,7 @@ rules:
     verbs:
       - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: nginx-ingress-role-{{ juju_application }}
@@ -173,7 +173,7 @@ rules:
       - get
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: nginx-ingress-role-nisa-binding-{{ juju_application }}
@@ -192,7 +192,7 @@ subjects:
     namespace: ingress-nginx-{{ juju_application }}
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: nginx-ingress-clusterrole-nisa-binding-{{ juju_application }}


### PR DESCRIPTION
This fixes two issues with nginx-ingress-controller.

# RBAC v1beta1 API no longer works

nginx-ingress-controller pods were in a crashloop:

```
$ kubectl get po -n ingress-nginx-kubernetes-worker
NAME                                               READY   STATUS             RESTARTS         AGE
nginx-ingress-controller-kubernetes-worker-2dngn   0/1     CrashLoopBackOff   29 (4m58s ago)   88m
nginx-ingress-controller-kubernetes-worker-527nf   0/1     CrashLoopBackOff   31 (4m50s ago)   89m
nginx-ingress-controller-kubernetes-worker-fzgdm   0/1     CrashLoopBackOff   30 (3s ago)      87m
```

With a permissions issue:

```
$ kubectl logs -n ingress-nginx-kubernetes-worker nginx-ingress-controller-kubernetes-worker-2dngn
F0813 18:23:47.585675       6 main.go:143] Unexpected error obtaining ingress-nginx pod: unable to get POD information: pods "nginx-ingress-controller-kubernetes-worker-2dngn" is forbidden: User "system:serviceaccount:ingress-nginx-kubernetes-worker:nginx-ingress-serviceaccount-kubernetes-worker" cannot get resource "pods" in API group "" in the namespace "ingress-nginx-kubernetes-worker"
```

Caused by a failure to apply RBAC rules:

```
unit-kubernetes-worker-0: 13:33:11 WARNING unit.kubernetes-worker/0.update-status unable to recognize "/root/cdk/addons/ingress-daemon-set.yaml": no matches for kind "ClusterRole" in version "rbac.authorization.k8s.io/v1beta1"
unit-kubernetes-worker-0: 13:33:11 WARNING unit.kubernetes-worker/0.update-status unable to recognize "/root/cdk/addons/ingress-daemon-set.yaml": no matches for kind "Role" in version "rbac.authorization.k8s.io/v1beta1"
unit-kubernetes-worker-0: 13:33:11 WARNING unit.kubernetes-worker/0.update-status unable to recognize "/root/cdk/addons/ingress-daemon-set.yaml": no matches for kind "RoleBinding" in version "rbac.authorization.k8s.io/v1beta1"
unit-kubernetes-worker-0: 13:33:11 WARNING unit.kubernetes-worker/0.update-status unable to recognize "/root/cdk/addons/ingress-daemon-set.yaml": no matches for kind "ClusterRoleBinding" in version "rbac.authorization.k8s.io/v1beta1"
```

The fix is to update RBAC apiVersions to `rbac.authorization.k8s.io/v1`.

# ingress v1beta1 API is deprecated, nginx-ingress-controller v0.45.0 still uses it

I don't have logs handy, but nginx-ingress-controller v0.45.0 fails to watch ingress resources via the v1beta1 API, which no longer exists in k8s 1.22. It's the same issue seen [here](https://github.com/kubernetes/ingress-nginx/issues/7448).

I also tried nginx-ingress-controller v0.48.1 and it has the same issue.

The fix is to upgrade to nginx-ingress-controller v1.0.0-beta.1, which uses the ingress v1 API instead. There is no stable release that supports ingress v1.