### PR TITLE
make 1.23/edge the default channel

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -17,7 +17,7 @@ options:
       cluster. Declare node labels in key=value format, separated by spaces.
   channel:
     type: string
-    default: "1.22/edge"
+    default: "1.23/edge"
     description: |
       Snap channel to install Kubernetes worker services from
   require-manual-upgrade:


### PR DESCRIPTION
Now that 1.22 is going stable, move our master branches up to 1.23/edge.