### PR TITLE
Added NRPE requested CPU governor check

### DIFF
--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -1127,6 +1127,12 @@ def update_nrpe_config():
 
         remove_state('nrpe-external-master.reconfigure')
         set_state('nrpe-external-master.initial-config')
+    # request CPU governor check from nrpe relation to be performance
+    rel_settings = {
+            'requested_cpu_governor': 'performance',
+            }
+    for rid in hookenv.relation_ids('nrpe-external-master'):
+        hookenv.relation_set(relation_id=rid, relation_settings=rel_settings)
 
 
 @when_not('nrpe-external-master.available')


### PR DESCRIPTION
Request from NRPE charm to check CPU governor to be performance for kubernetes-worker charm via the nrpe-external-master relation.

Both juju-info and nrpe-external-master must be present between the principal kubernetes-worker unit and nrpe.

Ref: https://code.launchpad.net/~dparv/charm-nrpe/+git/charm-nrpe/+merge/407897
