### PR TITLE
Remove call to CNI relation set_config

### DIFF
--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -677,14 +677,6 @@ def start_worker():
     remove_state('kubernetes-worker.restart-needed')
 
 
-@when('cni.connected')
-@when_not('cni.configured')
-def configure_cni(cni):
-    ''' Set worker configuration on the CNI relation. This lets the CNI
-    subordinate know that we're the worker so it can respond accordingly. '''
-    cni.set_config(is_master=False)
-
-
 @when('config.changed.labels')
 def handle_labels_changed():
     set_state('kubernetes-worker.label-config-required')


### PR DESCRIPTION
CNI subordinate behavior will no longer differ between masters and workers. As such, `is_master` is being removed from the CNI relation, and since there is no other config to set, `cni.set_config` is going away too. So this just cleans up nicely.

This is needed to support adding kubelet to kubernetes-master.