### PR TITLE
Remove CNI plugin resource code, move "Missing CNI resource" status

### DIFF
--- a/build-cni-resources.sh
+++ b/build-cni-resources.sh
@@ -2,6 +2,9 @@
 
 set -eux
 
+# When changing CNI_VERSION, it should be updated in both
+# charm-kubernetes-master/build-cni-resources.sh and
+# charm-kubernetes-worker/build-cni-resources.sh
 CNI_VERSION="${CNI_VERSION:-v0.7.5}"
 ARCH="${ARCH:-amd64 arm64 s390x}"
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -49,18 +49,6 @@ provides:
   ingress-proxy:
     interface: http
 resources:
-  cni-amd64:
-    type: file
-    filename: cni.tgz
-    description: CNI plugins for amd64
-  cni-arm64:
-    type: file
-    filename: cni.tgz
-    description: CNI plugins for arm64
-  cni-s390x:
-    type: file
-    filename: cni.tgz
-    description: CNI plugins for s390x
   core:
     type: file
     filename: core.snap


### PR DESCRIPTION
The CNI resources were previously handled by kubernetes-worker. We want them on kubernetes-master too, so, move the resource definitions and code to the shared base layer.

This is needed for kubelets on masters.