### PR TITLE
make 1.23/stable the default channel

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -17,7 +17,7 @@ options:
       cluster. Declare node labels in key=value format, separated by spaces.
   channel:
     type: string
-    default: "1.23/edge"
+    default: "1.23/stable"
     description: |
       Snap channel to install Kubernetes worker services from
   require-manual-upgrade:


### PR DESCRIPTION
In preparation for the 1.23 release, make 1.23/stable the default channel in the `stable` branch.