### PR TITLE
inclusive naming for kubernetes-master

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@master
+        uses: charmed-kubernetes/actions-operator@main
         with:
           provider: vsphere
           credentials-yaml: ${{ secrets.CREDENTIALS_YAML }}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This charm deploys a container runtime, and additionally stands up the Kubernete
 worker applications: kubelet, and kube-proxy.
 
 In order for this charm to be useful, it should be deployed with its companion
-charm [kubernetes-master](https://jujucharms.com/u/containers/kubernetes-master)
+charm [kubernetes-control-plane](https://jujucharms.com/u/containers/kubernetes-master)
 and linked with an SDN-Plugin and a container runtime such as
 [containerd](https://jaas.ai/u/containers/containerd).
 

--- a/build-cni-resources.sh
+++ b/build-cni-resources.sh
@@ -3,7 +3,7 @@
 set -eux
 
 # When changing CNI_VERSION, it should be updated in both
-# charm-kubernetes-master/build-cni-resources.sh and
+# charm-kubernetes-control-plane/build-cni-resources.sh and
 # charm-kubernetes-worker/build-cni-resources.sh
 CNI_VERSION="${CNI_VERSION:-v0.7.5}"
 ARCH="${ARCH:-amd64 arm64 s390x}"

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -26,7 +26,7 @@ requires:
   kube-api-endpoint:
     # kube-api-endpoint is not recommended as the API endpoints will be provided
     # via the kube-control relation. However, it can be used to override those
-    # endpoints if you need to inject a reverse proxy between the master and workers.
+    # endpoints if you need to inject a reverse proxy between the control-plane and workers.
     interface: http
   kube-control:
     interface: kube-control

--- a/tests/data/bundle.yaml
+++ b/tests/data/bundle.yaml
@@ -21,15 +21,11 @@ services:
     to:
     - '1'
   etcd:
-    charm: cs:~containers/etcd
-    channel: edge
+    charm: etcd
+    channel: latest/edge
     num_units: 1
     options:
       channel: 3.4/stable
-    resources:
-      core: 0
-      etcd: 3
-      snapshot: 0
     to:
     - '0'
   flannel:
@@ -40,21 +36,13 @@ services:
       flannel-arm64: 650
       flannel-s390x: 637
   kubernetes-control-plane:
-    charm: cs:~containers/kubernetes-master
-    channel: edge
+    charm: kubernetes-control-plane
+    channel: latest/edge
     constraints: cores=2 mem=4G root-disk=16G
     expose: true
     num_units: 1
     options:
       channel: 1.20/stable
-    resources:
-      cdk-addons: 0
-      core: 0
-      kube-apiserver: 0
-      kube-controller-manager: 0
-      kube-proxy: 0
-      kube-scheduler: 0
-      kubectl: 0
     to:
     - '0'
   kubernetes-worker:

--- a/tests/data/bundle.yaml
+++ b/tests/data/bundle.yaml
@@ -39,7 +39,7 @@ services:
       flannel-amd64: 653
       flannel-arm64: 650
       flannel-s390x: 637
-  kubernetes-master:
+  kubernetes-control-plane:
     charm: cs:~containers/kubernetes-master
     channel: edge
     constraints: cores=2 mem=4G root-disk=16G
@@ -75,11 +75,11 @@ services:
     to:
     - '1'
 relations:
-- - kubernetes-master:kube-control
+- - kubernetes-control-plane:kube-control
   - kubernetes-worker:kube-control
-- - kubernetes-master:certificates
+- - kubernetes-control-plane:certificates
   - easyrsa:client
-- - kubernetes-master:etcd
+- - kubernetes-control-plane:etcd
   - etcd:db
 - - kubernetes-worker:certificates
   - easyrsa:client
@@ -88,10 +88,10 @@ relations:
 - - flannel:etcd
   - etcd:db
 - - flannel:cni
-  - kubernetes-master:cni
+  - kubernetes-control-plane:cni
 - - flannel:cni
   - kubernetes-worker:cni
 - - containerd:containerd
   - kubernetes-worker:container-runtime
 - - containerd:containerd
-  - kubernetes-master:container-runtime
+  - kubernetes-control-plane:container-runtime

--- a/tests/integration/test_kubernetes_worker_integration.py
+++ b/tests/integration/test_kubernetes_worker_integration.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import logging
 from urllib.request import urlretrieve
 from pathlib import Path
@@ -88,9 +89,9 @@ async def test_build_and_deploy(ops_test, setup_resources):
     try:
         await ops_test.model.wait_for_idle(wait_for_active=True, timeout=60 * 60)
     except asyncio.TimeoutError:
-        if "kubernetes-master" not in ops_test.model.applications:
+        if "kubernetes-control-plane" not in ops_test.model.applications:
             raise
-        app = ops_test.model.applications["kubernetes-master"]
+        app = ops_test.model.applications["kubernetes-control-plane"]
         if not app.units:
             raise
         unit = app.units[0]
@@ -123,10 +124,18 @@ async def test_kube_api_endpoint(ops_test):
     # wait_for_idle giving a false positive.
     k8s_cp = ops_test.model.applications["kubernetes-control-plane"].units[0]
     waiting_msg = "Waiting for kube-api-endpoint relation"
-    await ops_test.model.block_until(
-        lambda: k8s_cp.workload_status_message == waiting_msg,
-        timeout=5 * 60,
-    )
+    try:
+        await ops_test.model.block_until(
+            lambda: k8s_cp.workload_status_message == waiting_msg,
+            timeout=5 * 60,
+        )
+    except asyncio.TimeoutError:
+        pass
+
+    goal_state = await juju_run(k8s_cp, "goal-state --format=json")
+    relation_status = json.loads(goal_state)
+    kube_api_endpoint = relation_status["relations"]["kube-api-endpoint"]
+    assert kube_api_endpoint["kubernetes-worker"]["status"] == "joined"
 
     await ops_test.model.wait_for_idle(wait_for_active=True, timeout=10 * 60)
     _check_status_messages(ops_test)

--- a/tests/integration/test_kubernetes_worker_integration.py
+++ b/tests/integration/test_kubernetes_worker_integration.py
@@ -116,7 +116,7 @@ async def test_kube_api_endpoint(ops_test):
     """Validate that adding the kube-api-endpoint relation works"""
     await ops_test.model.add_relation(
         "kubernetes-control-plane:kube-api-endpoint",
-        "kubernetes-control-plane:kube-api-endpoint",
+        "kubernetes-worker:kube-api-endpoint",
     )
 
     # It can take some time for the relation hook to trigger, which can lead to

--- a/tests/integration/test_kubernetes_worker_integration.py
+++ b/tests/integration/test_kubernetes_worker_integration.py
@@ -10,9 +10,9 @@ log = logging.getLogger(__name__)
 
 
 def _check_status_messages(ops_test):
-    """ Validate that the status messages are correct. """
+    """Validate that the status messages are correct."""
     expected_messages = {
-        "kubernetes-master": "Kubernetes master running.",
+        "kubernetes-control-plane": "Kubernetes master running.",
         "kubernetes-worker": "Kubernetes worker running.",
     }
     for app, message in expected_messages.items():
@@ -54,17 +54,18 @@ async def test_build_and_deploy(ops_test):
 
 
 async def test_kube_api_endpoint(ops_test):
-    """ Validate that adding the kube-api-endpoint relation works """
+    """Validate that adding the kube-api-endpoint relation works"""
     await ops_test.model.add_relation(
-        "kubernetes-master:kube-api-endpoint", "kubernetes-worker:kube-api-endpoint"
+        "kubernetes-control-plane:kube-api-endpoint",
+        "kubernetes-control-plane:kube-api-endpoint",
     )
 
     # It can take some time for the relation hook to trigger, which can lead to
     # wait_for_idle giving a false positive.
-    k8s_master = ops_test.model.applications["kubernetes-master"].units[0]
+    k8s_cp = ops_test.model.applications["kubernetes-control-plane"].units[0]
     waiting_msg = "Waiting for kube-api-endpoint relation"
     await ops_test.model.block_until(
-        lambda: k8s_master.workload_status_message == waiting_msg,
+        lambda: k8s_cp.workload_status_message == waiting_msg,
         timeout=5 * 60,
     )
 


### PR DESCRIPTION
* Updates the application name in the integration testing to remove the word master
* Updates some charms to pull from charmhub rather than charmstore
* Updates readme/docs to use the name `kubernetes-control-plane`