### PR TITLE
Add support for has_xcp flag on kube-control

### DIFF
--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -620,9 +620,12 @@ def start_worker():
     creds = db.get('credentials')
     data_changed('kube-control.creds', creds)
 
+    # older kube-control doesn't have has_xcp flag
+    has_xcp = getattr(kube_control, 'has_xcp', False)
+
     create_config(servers[get_unit_number() % len(servers)], creds)
     configure_default_cni(kube_control.get_default_cni())
-    configure_kubelet(dns_domain, dns_ip, registry, has_xcp=kube_control.has_xcp)
+    configure_kubelet(dns_domain, dns_ip, registry, has_xcp=has_xcp)
     configure_kube_proxy(configure_prefix, servers,
                          cluster_cidr)
     set_state('kubernetes-worker.config.created')

--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -589,7 +589,8 @@ def watch_for_changes():
           'kubernetes-worker.cloud.blocked',
           'upgrade.series.in-progress')
 @when_any('kube-control.api_endpoints.available',
-          'kube-api-endpoint.available')
+          'kube-api-endpoint.available',
+          'endpoint.kube-control.has-xcp.changed')
 def start_worker():
     ''' Start kubelet using the provided API and DNS info.'''
     # Note that the DNS server doesn't necessarily exist at this point. We know
@@ -621,7 +622,7 @@ def start_worker():
 
     create_config(servers[get_unit_number() % len(servers)], creds)
     configure_default_cni(kube_control.get_default_cni())
-    configure_kubelet(dns_domain, dns_ip, registry)
+    configure_kubelet(dns_domain, dns_ip, registry, has_xcp=kube_control.has_xcp)
     configure_kube_proxy(configure_prefix, servers,
                          cluster_cidr)
     set_state('kubernetes-worker.config.created')
@@ -630,6 +631,7 @@ def start_worker():
     set_state('kubernetes-worker.label-config-required')
     set_state('nrpe-external-master.reconfigure')
     remove_state('kubernetes-worker.restart-needed')
+    remove_state('endpoint.kube-control.has-xcp.changed')
 
 
 @when('config.changed.labels')

--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -625,7 +625,11 @@ def start_worker():
 
     create_config(servers[get_unit_number() % len(servers)], creds)
     configure_default_cni(kube_control.get_default_cni())
-    configure_kubelet(dns_domain, dns_ip, registry, has_xcp=has_xcp)
+    try:
+        configure_kubelet(dns_domain, dns_ip, registry, has_xcp=has_xcp)
+    except TypeError:
+        # older kubernetes-common doesn't support the has_xcp flag
+        configure_kubelet(dns_domain, dns_ip, registry)
     configure_kube_proxy(configure_prefix, servers,
                          cluster_cidr)
     set_state('kubernetes-worker.config.created')

--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -620,16 +620,9 @@ def start_worker():
     creds = db.get('credentials')
     data_changed('kube-control.creds', creds)
 
-    # older kube-control doesn't have has_xcp flag
-    has_xcp = getattr(kube_control, 'has_xcp', False)
-
     create_config(servers[get_unit_number() % len(servers)], creds)
     configure_default_cni(kube_control.get_default_cni())
-    try:
-        configure_kubelet(dns_domain, dns_ip, registry, has_xcp=has_xcp)
-    except TypeError:
-        # older kubernetes-common doesn't support the has_xcp flag
-        configure_kubelet(dns_domain, dns_ip, registry)
+    configure_kubelet(dns_domain, dns_ip, registry, has_xcp=kube_control.has_xcp)
     configure_kube_proxy(configure_prefix, servers,
                          cluster_cidr)
     set_state('kubernetes-worker.config.created')

--- a/tests/unit/test_kubernetes_worker.py
+++ b/tests/unit/test_kubernetes_worker.py
@@ -1,11 +1,17 @@
 import pathlib
 import unittest.mock
+from collections import defaultdict
 
 import pytest
-from unittest.mock import patch
+from unittest.mock import patch, ANY
 from reactive import kubernetes_worker
-from charms.reactive import set_flag, clear_flag
-from charmhelpers.core import hookenv
+from charms.reactive import (  # auto-mocked
+    set_flag, clear_flag,
+    endpoint_from_flag,
+    endpoint_from_name,
+)
+from charmhelpers.core import hookenv  # auto-mocked
+from charms.layer import kubernetes_common  # auto-mocked
 
 
 def patch_fixture(patch_target):
@@ -75,3 +81,18 @@ def test_deprecated_extra_args(mock_check_output, request):
         ("kubelet-extra-args", "alsologtostderr"),
         ("proxy-extra-args", "log-dir"),
     ]
+
+
+@unittest.mock.patch("reactive.kubernetes_worker.check_call")
+@unittest.mock.patch("reactive.kubernetes_worker.deprecated_extra_args")
+def test_xcp(dea, *_):
+    dea.return_value = []
+    kubernetes_worker.db.set("credentials", defaultdict(str))
+    endpoint_from_flag().has_xcp = False
+    endpoint_from_name().services.return_value = [
+        {"hosts": [{"hostname": "foo", "port": "80"}]}
+    ]
+    kubernetes_common.get_unit_number.return_value = 0
+    kubernetes_worker.start_worker()
+    assert kubernetes_worker.configure_kubelet.called
+    assert kubernetes_worker.configure_kubelet.call_args == (ANY, {"has_xcp": False})

--- a/tests/unit/test_kubernetes_worker.py
+++ b/tests/unit/test_kubernetes_worker.py
@@ -96,3 +96,7 @@ def test_xcp(dea, *_):
     kubernetes_worker.start_worker()
     assert kubernetes_worker.configure_kubelet.called
     assert kubernetes_worker.configure_kubelet.call_args == (ANY, {"has_xcp": False})
+
+    endpoint_from_flag().has_xcp = True
+    kubernetes_worker.start_worker()
+    assert kubernetes_worker.configure_kubelet.call_args == (ANY, {"has_xcp": True})


### PR DESCRIPTION
Adds support for the new `has_xcp` flag to drive the `cloud-provider=external` config instead of (or in addition to) the integrator relation.

Depends on:
* https://github.com/juju-solutions/interface-kube-control/pull/34
* https://github.com/charmed-kubernetes/layer-kubernetes-common/pull/24