### PR TITLE
bump ingress-nginx to latest version

### DIFF
--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -843,7 +843,7 @@ def render_and_launch_ingress():
             context["ingress_image"] = "/".join(
                 [
                     registry_location or "us.gcr.io",
-                    "k8s-artifacts-prod/ingress-nginx/controller:v1.0.0-beta.3",
+                    "k8s-artifacts-prod/ingress-nginx/controller:v1.1.3",
                 ]
             )
 


### PR DESCRIPTION
Bump ingress-nginx to latest supported version (1.1.3):

https://github.com/kubernetes/ingress-nginx#support-versions-table

Note: this depends on https://github.com/charmed-kubernetes/bundle/pull/829 being merged and `sync-oci-images` being run.