### PR TITLE
lp1969972 upgrade ingress-nginx

### DIFF
--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -843,7 +843,7 @@ def render_and_launch_ingress():
             context["ingress_image"] = "/".join(
                 [
                     registry_location or "us.gcr.io",
-                    "k8s-artifacts-prod/ingress-nginx/controller:v1.1.3",
+                    "k8s-artifacts-prod/ingress-nginx/controller:v1.2.0",
                 ]
             )
 

--- a/tests/integration/test_kubernetes_worker_integration.py
+++ b/tests/integration/test_kubernetes_worker_integration.py
@@ -31,7 +31,7 @@ async def test_build_and_deploy(ops_test):
     resources = await ops_test.build_resources(build_script)
     expected_resources = {"cni-amd64", "cni-arm64", "cni-s390x"}
 
-    if all(rsc.stem in expected_resources for rsc in resources):
+    if resources and all(rsc.stem in expected_resources for rsc in resources):
         resources = {rsc.stem.replace("-", "_"): rsc for rsc in resources}
     else:
         log.info("Failed to build resources, downloading from latest/edge")


### PR DESCRIPTION
Bump ingress-nginx to latest supported version (1.2.0):

https://github.com/kubernetes/ingress-nginx#support-versions-table

Note: this depends on https://github.com/charmed-kubernetes/bundle/pull/830 being merged and sync-oci-images being run.

Fixes https://bugs.launchpad.net/charmed-kubernetes-bundles/+bug/1969972