### PR TITLE
make 1.24/stable the default channel on the stable branch

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -11,7 +11,7 @@ options:
         juju run --application kubernetes-worker -- open-port 80 && open-port 443
   channel:
     type: string
-    default: "1.23/edge"
+    default: "1.24/stable"
     description: |
       Snap channel to install Kubernetes worker services from
   require-manual-upgrade:


### PR DESCRIPTION
In preparation for the 1.24 release, make 1.24/stable the default channel in the stable branch.