### PR TITLE
Add resusable workflows for Lint, Unit, and Wheelhouse validation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,38 +8,14 @@ jobs:
     with:
       fail-on-error: "true"
 
-  test-wheelhouse:
-    name: Test Wheelhouse
-    runs-on: ubuntu-latest
-    steps:
-    - name: Check out code
-      uses: actions/checkout@v2
-    - name: Setup Python
-      uses: actions/setup-python@v2
-    - name: Install Dependencies
-      run: |
-        pip install tox
-        sudo snap install charm --classic
-    - name: Run validate-wheelhouse
-      run: tox -vve validate-wheelhouse
+  validate-wheelhouse:
+    name: Validate Wheelhouse
+    uses: charmed-kubernetes/workflows/.github/workflows/validate-wheelhouse.yaml@main
+
   lint-unit:
-    name: Lint, Unit
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python: [3.6, 3.7, 3.8, 3.9]
-    steps:
-    - name: Check out code
-      uses: actions/checkout@v2
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python }}
-    - name: Install Dependencies
-      run: |
-        pip install tox
-    - name: Run lint and unit tests
-      run: tox -vve lint, unit
+    name: Lint Unit
+    uses: charmed-kubernetes/workflows/.github/workflows/lint-unit.yaml@main
+
   integration-test:
     name: Integration test with VMWare
     runs-on: self-hosted


### PR DESCRIPTION
This PR showcases some of the utility of reusable workflows and how we can use them to cut down on github action boilerplate, and use centrally-managed workflows in our CI. The workflows themselves are located [here](https://github.com/charmed-kubernetes/workflows).

Do not merge until the content of the workflows have been further discussed