### PR TITLE
use charmhelpers.core.templating.render method with appropriate args

### DIFF
--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -966,7 +966,7 @@ def get_kube_api_servers():
 @when_any("kube-control.api_endpoints.available", "kube-api-endpoint.available")
 def update_nrpe_config():
     services = ["snap.{}.daemon".format(s) for s in worker_services]
-    data = render("nagios_plugin.py", context={"node_name": get_node_name()})
+    data = render("nagios_plugin.py", None, {"node_name": get_node_name()})
     plugin_path = install_nagios_plugin_from_text(data, "check_k8s_worker.py")
     hostname = nrpe.get_nagios_hostname()
     current_unit = nrpe.get_nagios_unit_name()


### PR DESCRIPTION
Using the wrong API led to [LP#1982972](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/1982972)

using [this API from `charmhelpers.core.templating`](https://github.com/juju/charm-helpers/blob/master/charmhelpers/core/templating.py#L21)

instead of [this one from `charms.templating.jinja2`](https://github.com/juju-solutions/charms.templating.jinja2/blob/master/charms/templating/jinja2.py#L27)