### PR TITLE
make 1.25/stable the default snap channel for release_1.25

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -11,7 +11,7 @@ options:
         juju run --application kubernetes-worker -- open-port 80 && open-port 443
   channel:
     type: string
-    default: "1.23/edge"
+    default: "1.25/stable"
     description: |
       Snap channel to install Kubernetes worker services from
   require-manual-upgrade:


### PR DESCRIPTION
In preparation for the 1.25 release, make 1.25/stable the default snap channel in the release branch.