### PR TITLE
Update default channel config to 1.27/edge

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -11,7 +11,7 @@ options:
         juju run --application kubernetes-worker -- open-port 80 && open-port 443
   channel:
     type: string
-    default: "1.23/edge"
+    default: "1.27/edge"
     description: |
       Snap channel to install Kubernetes worker services from
   require-manual-upgrade:

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,7 @@ deps =
     pytest
     pytest-operator
     ipdb
+    juju < 3.1
 commands = pytest --tb native --show-capture=no --log-cli-level=INFO -s {posargs} {toxinidir}/tests/integration
 
 [testenv:lint]


### PR DESCRIPTION
Kinda fixes https://bugs.launchpad.net/bugs/2007162

1.23/edge is quite out of date, and some deployments are picking up this default. Update it to something more appopriate for edge builds from the main branch.