### PR TITLE
Add ignore-missing-cni config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -91,3 +91,9 @@ options:
       as possible. You may also set a custom string as described in the
       'refresh.timer' section here:
         https://forum.snapcraft.io/t/system-options/87
+  ignore-missing-cni:
+    type: boolean
+    default: false
+    description: |
+      If ignore-missing-cni is set to true, the charm will not enter a blocked state if a CNI has not been configured/provided via relation.
+      If ignore-missing-cni is set to false, and a CNI has not been configured/provided via relation, then the charm will enter a blocked state with the message: "Missing CNI relation or config".

--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -433,6 +433,7 @@ def charm_status():
     cloud_blocked = is_state("kubernetes-worker.cloud.blocked")
     cni_available = is_state("cni.available")
     cni_related = "cni" in goal_state.get("relations", {})
+    ignore_missing_cni = hookenv.config("ignore-missing-cni")
 
     if is_state("upgrade.series.in-progress"):
         hookenv.status_set("blocked", "Series upgrade in progress")
@@ -454,7 +455,12 @@ def charm_status():
     if not is_flag_set("kubernetes.cni-plugins.installed"):
         hookenv.status_set("blocked", "Missing CNI resource")
         return
-    if not cni_available and not cni_related and not cni_config_exists():
+    if (
+        not cni_available
+        and not cni_related
+        and not cni_config_exists()
+        and not ignore_missing_cni
+    ):
         hookenv.status_set("blocked", "Missing CNI relation or config")
         return
     if is_state("kubernetes-worker.cloud.pending"):


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/bugs/2009525 for kubernetes-worker

Do the same thing as https://github.com/charmed-kubernetes/charm-kubernetes-control-plane/pull/275, but for kubernetes-worker. This is needed to allow CAPI deployments to progress to active/idle status without a CNI.

I haven't tested this yet but will do so.