### PR TITLE
bump ingress image for 1.27

### DIFF
--- a/reactive/kubernetes_worker.py
+++ b/reactive/kubernetes_worker.py
@@ -836,7 +836,7 @@ def render_and_launch_ingress():
         if registry_location:
             backend_registry = registry_location
         else:
-            backend_registry = "k8s.gcr.io"
+            backend_registry = "registry.k8s.io"
         if context["arch"] == "s390x":
             context["defaultbackend_image"] = "{}/defaultbackend-s390x:1.4".format(
                 backend_registry
@@ -883,8 +883,8 @@ def render_and_launch_ingress():
             context["ingress_uid"] = "101"
             context["ingress_image"] = "/".join(
                 [
-                    registry_location or "us.gcr.io",
-                    "k8s-artifacts-prod/ingress-nginx/controller:v1.2.0",
+                    registry_location or "registry.k8s.io",
+                    "ingress-nginx/controller:v1.6.4",
                 ]
             )
 


### PR DESCRIPTION
Update k8s.gcr.io references and bump the ingress image.  We haven't done a version bump since v1.2.0, so we're staying with the latest release that has overlapping k8s support:

https://github.com/kubernetes/ingress-nginx#supported-versions-table

Depends on: https://github.com/charmed-kubernetes/bundle/pull/878

Fixes: https://bugs.launchpad.net/charmed-kubernetes-bundles/+bug/2015552