### PR TITLE
Synchronize `Kubernetes Worker` with `Kubernetes Control Plane`

### DIFF
--- a/.github/workflows/vsphere-integration.yaml
+++ b/.github/workflows/vsphere-integration.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: 3.8
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
@@ -21,12 +21,20 @@ jobs:
           credentials-yaml: ${{ secrets.CREDENTIALS_YAML }}
           clouds-yaml: ${{ secrets.CLOUDS_YAML }}
           bootstrap-constraints: "arch=amd64 cores=2 mem=4G"
-          bootstrap-options: "${{ secrets.JAMMY_BOOTSTRAP_OPTIONS }} --model-default datastore=vsanDatastore --model-default primary-network=VLAN_2763"
+          bootstrap-options: >-
+            ${{ secrets.JAMMY_BOOTSTRAP_OPTIONS }}
+            --model-default datastore=vsanDatastore
+            --model-default primary-network=VLAN_2763
+            --model-default force-vm-hardware-version=17
       - name: Run test
-        run: tox -e integration
+        run: tox -e integration -- --basetemp=/home/ubuntu/pytest
       - name: Setup Debug Artifact Collection
         if: ${{ failure() }}
         run: mkdir tmp
+      - name: Collect Charmcraft Errors
+        if: ${{ failure() }}
+        run: |
+          mv /home/ubuntu/.local/state/charmcraft/log/* tmp/ | true
       - name: Collect Juju Status
         if: ${{ failure() }}
         run: |
@@ -35,7 +43,7 @@ jobs:
           mv juju-crashdump-* tmp/ | true
       - name: Upload debug artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: test-run-artifacts
           path: tmp

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,69 @@
 options:
   channel:
     type: string
-    default: "1.27/edge"
+    default: "1.28/edge"
     description: |
       Snap channel to install Kubernetes worker services from
+  kubelet-extra-args:
+    type: string
+    default: ""
+    description: |
+      Space separated list of flags and key=value pairs that will be passed as arguments to
+      kubelet. For example a value like this:
+        runtime-config=batch/v2alpha1=true profiling=true
+      will result in kubelet being run with the following options:
+        --runtime-config=batch/v2alpha1=true --profiling=true
+      Note: As of Kubernetes 1.10.x, many of Kubelet's args have been deprecated, and can
+      be set with kubelet-extra-config instead.
+  kubelet-extra-config:
+    default: "{}"
+    type: string
+    description: |
+      Extra configuration to be passed to kubelet. Any values specified in this
+      config will be merged into a KubeletConfiguration file that is passed to
+      the kubelet service via the --config flag. This can be used to override
+      values provided by the charm.
+
+      The value for this config must be a YAML mapping that can be safely
+      merged with a KubeletConfiguration file. For example:
+        {evictionHard: {memory.available: 200Mi}}
+
+      For more information about KubeletConfiguration, see upstream docs:
+      https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/
+  proxy-extra-args:
+    type: string
+    default: ""
+    description: |
+      Space separated list of flags and key=value pairs that will be passed as arguments to
+      kube-proxy. For example a value like this:
+        runtime-config=batch/v2alpha1=true profiling=true
+      will result in kube-apiserver being run with the following options:
+        --runtime-config=batch/v2alpha1=true --profiling=true
+  proxy-extra-config:
+    default: "{}"
+    type: string
+    description: |
+      Extra configuration to be passed to kube-proxy. Any values specified in
+      this config will be merged into a KubeProxyConfiguration file that is
+      passed to the kube-proxy service via the --config flag. This can be used
+      to override values provided by the charm.
+
+      The value for this config must be a YAML mapping that can be safely
+      merged with a KubeProxyConfiguration file. For example:
+        {mode: ipvs, ipvs: {strictARP: true}}
+
+      For more information about KubeProxyConfiguration, see upstream docs:
+      https://kubernetes.io/docs/reference/config-api/kube-proxy-config.v1alpha1/
+  sysctl:
+    type: string
+    default: "{net.ipv4.conf.all.forwarding: 1, net.ipv4.conf.all.rp_filter: 1, net.ipv4.neigh.default.gc_thresh1: 128, net.ipv4.neigh.default.gc_thresh2: 28672, net.ipv4.neigh.default.gc_thresh3: 32768, net.ipv6.neigh.default.gc_thresh1: 128, net.ipv6.neigh.default.gc_thresh2: 28672, net.ipv6.neigh.default.gc_thresh3: 32768, fs.inotify.max_user_instances: 8192, fs.inotify.max_user_watches: 1048576, kernel.panic: 10, kernel.panic_on_oops: 1, vm.overcommit_memory: 1}"
+    description: |
+      YAML formatted associative array of sysctl values, e.g.:
+      '{kernel.pid_max: 4194303}'. Note that kube-proxy handles
+      the conntrack settings. The proper way to alter them is to
+      use the proxy-extra-args config to set them, e.g.:
+        juju config kubernetes-control-plane proxy-extra-args="conntrack-min=1000000 conntrack-max-per-core=250000"
+        juju config kubernetes-worker proxy-extra-args="conntrack-min=1000000 conntrack-max-per-core=250000"
+      The proxy-extra-args conntrack-min and conntrack-max-per-core can be set to 0 to ignore
+      kube-proxy's settings and use the sysctl settings instead. Note the fundamental difference between
+      the setting of conntrack-max-per-core vs nf_conntrack_max.

--- a/config.yaml
+++ b/config.yaml
@@ -13,8 +13,6 @@ options:
         runtime-config=batch/v2alpha1=true profiling=true
       will result in kubelet being run with the following options:
         --runtime-config=batch/v2alpha1=true --profiling=true
-      Note: As of Kubernetes 1.10.x, many of Kubelet's args have been deprecated, and can
-      be set with kubelet-extra-config instead.
   kubelet-extra-config:
     default: "{}"
     type: string

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,22 +1,27 @@
-# This file populates the Overview on Charmhub.
-
-# The charm package name, no spaces (required)
-# See https://juju.is/docs/sdk/naming#heading--naming-charms for guidance.
+# Copyright 2023 Canonical, Ltd.
+# See LICENSE file for licensing details.
 name: kubernetes-worker
-
-# The following metadata are human-readable and will be published prominently on Charmhub.
-
-# (Recommended)
-display-name: Charm Template
-
-# (Required)
-summary: A very short one-line summary of the charm.
-
+display-name: Kubernetes Worker
+summary: The workload bearing units of a Kubernetes cluster.
 description: |
-  A single sentence that says what the charm is, concisely and memorably.
-
-  A paragraph of one to three short sentences, that describe what the charm does.
-
-  A third paragraph that explains what need the charm meets.
-
-  Finally, a paragraph that describes whom the charm is useful for.
+  Kubernetes is an open-source platform for deploying, scaling, and operations
+  of application containers across a cluster of hosts. Kubernetes is portable
+  in that it works with public, private, and hybrid clouds. Extensible through
+  a pluggable infrastructure. Self healing in that it will automatically
+  restart and place containers on healthy nodes if a node ever goes away.
+series:
+  - jammy
+  - focal
+subordinate: false
+provides:
+  cni:
+    interface: kubernetes-cni
+    scope: container
+  container-runtime:
+    interface: container-runtime
+    scope: container
+requires:
+  certificates:
+    interface: tls-certificates
+  kube-control:
+    interface: kube-control

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -3,12 +3,18 @@
 name: kubernetes-worker
 display-name: Kubernetes Worker
 summary: The workload bearing units of a Kubernetes cluster.
+maintainers:
+  - Kevin Monroe <kevin.monroe@canonical.com>  
+  - George Kraft <george.kraft@canonical.com>
+  - Mateo Florido <mateo.florido@canonical.com>
+  - Adam Dyess <adam.dyess@canonical.com>  
 description: |
   Kubernetes is an open-source platform for deploying, scaling, and operations
   of application containers across a cluster of hosts. Kubernetes is portable
   in that it works with public, private, and hybrid clouds. Extensible through
   a pluggable infrastructure. Self healing in that it will automatically
   restart and place containers on healthy nodes if a node ever goes away.
+docs: https://discourse.charmhub.io/t/kubernetes-worker-docs-index/6104
 series:
   - jammy
   - focal

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,9 @@
 charm-lib-contextual-status @ git+https://github.com/charmed-kubernetes/charm-lib-contextual-status
-charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps
+charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps@69476eea079d95e0b1726b5595bf80985576ad23
 charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler
 ops >= 2.2.0
+ops.interface_tls_certificates @ git+https://github.com/juju-solutions/interface-tls-certificates#subdirectory=ops
+charm-lib-interface-kubernetes-cni @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kubernetes-cni
+git+https://github.com/charmed-kubernetes/interface-kube-control.git@6dd289d1c795fdeda1bed17873b8d6562227c829#subdirectory=ops
+charm-lib-interface-container-runtime @ git+https://github.com/charmed-kubernetes/charm-lib-interface-container-runtime
+pydantic==1.*

--- a/src/charm.py
+++ b/src/charm.py
@@ -2,27 +2,229 @@
 # Copyright 2023 Canonical
 # See LICENSE file for licensing details.
 
-"""Charm."""
+"""Charmed Machine Operator for Kubernetes Worker."""
 
 import logging
+from pathlib import Path
+from socket import gethostname
 
+import charms.contextual_status as status
 import ops
+import yaml
 from charms import kubernetes_snaps
-from charms.reconciler import Reconciler
+from charms.interface_container_runtime import ContainerRuntimeProvides
+from charms.interface_kubernetes_cni import KubernetesCniProvides
+from charms.reconciler import BlockedStatus, Reconciler
+from ops.interface_kube_control import KubeControlRequirer
+from ops.interface_tls_certificates import CertificatesRequires
+from ops.model import MaintenanceStatus, WaitingStatus
 
 log = logging.getLogger(__name__)
 
+ROOT_KUBECONFIG_PATH = Path("/root/.kube/config")
+UBUNTU_KUBECONFIG_PATH = Path("/home/ubuntu/.kube/config")
+KUBELET_KUBECONFIG_PATH = Path("/root/cdk/kubeconfig")
+KUBEPROXY_KUBECONFIG_PATH = Path("/root/cdk/kubeproxyconfig")
+
 
 class KubernetesWorkerCharm(ops.CharmBase):
-    """Charm."""
+    """Charmed Operator for Kubernetes Worker."""
 
     def __init__(self, *args):
         super().__init__(*args)
+        self.certificates = CertificatesRequires(self, endpoint="certificates")
+        self.cni = KubernetesCniProvides(self, endpoint="cni", default_cni="")
+        self.container_runtime = ContainerRuntimeProvides(self, endpoint="container-runtime")
+        self.kube_control = KubeControlRequirer(self)
         self.reconciler = Reconciler(self, self.reconcile)
+
+    def _check_kubecontrol_integration(self, event) -> bool:
+        """Check the integration status with kube-control."""
+        log.info("Checking kube-control integration")
+        evaluation = self.kube_control.evaluate_relation(event)
+        if evaluation:
+            current_status = (
+                WaitingStatus(evaluation) if "Waiting" in evaluation else BlockedStatus(evaluation)
+            )
+            status.add(current_status)
+            log.info(f"kube-control integration status: {evaluation}")
+            return False
+        return True
+
+    def _configure_cni(self):
+        """Configure the CNI integration databag."""
+        registry = self.kube_control.get_registry_location()
+        if registry:
+            self.cni.set_image_registry(registry)
+            self.cni.set_kubeconfig_hash_from_file(str(ROOT_KUBECONFIG_PATH))
+            kubernetes_snaps.set_default_cni_conf_file(self.kube_control.get_default_cni())
+
+    def _configure_container_runtime(self):
+        """Configure the container runtime in the node."""
+        if not self.container_runtime.relations:
+            status.add(BlockedStatus("Missing container-runtime integration"))
+            return
+
+        registry = self.kube_control.get_registry_location()
+        if registry:
+            sandbox_image = kubernetes_snaps.get_sandbox_image(registry)
+            self.container_runtime.set_sandbox_image(sandbox_image)
+
+    def _configure_kernel_parameters(self):
+        """Configure the Kernel with the provided configuration."""
+        status.add(MaintenanceStatus("Configuring Kernel parameters"))
+
+        sysctl = yaml.safe_load(self.model.config.get("sysctl"))
+        kubernetes_snaps.configure_kernel_parameters(sysctl)
+
+    def _configure_kubelet(self, event):
+        """Configure kubelet with the configuration parameters."""
+        status.add(MaintenanceStatus("Configuring kubelet"))
+        if not self._check_kubecontrol_integration(event):
+            return
+
+        dns = self.kube_control.get_dns()
+        kubernetes_snaps.configure_kubelet(
+            container_runtime_endpoint=self.container_runtime.socket,
+            dns_domain=dns.get("domain"),
+            dns_ip=dns.get("sdn-ip"),
+            extra_args_config=self.model.config.get("kubelet-extra-args"),
+            extra_config=yaml.safe_load(self.model.config.get("kubelet-extra-config")),
+            has_xcp=self.kube_control.has_xcp,
+            kubeconfig=str(KUBELET_KUBECONFIG_PATH),
+            node_ip=self.model.get_binding("kube-control").network.ingress_address.exploded,
+            registry=self.kube_control.get_registry_location(),
+            taints=None,
+        )
+
+    def _configure_kubeproxy(self, event):
+        """Configure kube-proxy with the configuration parameters."""
+        status.add(MaintenanceStatus("Configuring kube-proxy"))
+        if not self._check_kubecontrol_integration(event):
+            return
+        kubernetes_snaps.configure_kube_proxy(
+            cluster_cidr=self.cni.cidr,
+            extra_args_config=self.model.config.get("proxy-extra-args"),
+            extra_config=yaml.safe_load(self.model.config.get("proxy-extra-config")),
+            kubeconfig=str(KUBEPROXY_KUBECONFIG_PATH),
+        )
+
+    def _create_kubeconfigs(self, event):
+        """Generate kubeconfig files for the cluster components."""
+        status.add(MaintenanceStatus("Generating Kubeconfig"))
+        ca = self.certificates.ca
+        if not ca:
+            status.add(WaitingStatus("Waiting for certificates"))
+            return
+
+        if not self._check_kubecontrol_integration(event):
+            return
+
+        node_user = f"system:node:{kubernetes_snaps.get_node_name()}"
+        credentials = self.kube_control.get_auth_credentials(node_user)
+        if not credentials:
+            status.add(WaitingStatus("Waiting for kube-control credentials"))
+            return False
+
+        servers = self.kube_control.get_api_endpoints()
+        if not servers:
+            status.add(WaitingStatus("Waiting for API endpoints URLs"))
+            return
+
+        server = servers[self._get_unit_number() % len(servers)]
+
+        # Create K8s config in the default location for Ubuntu.
+        kubernetes_snaps.create_kubeconfig(
+            dest=str(UBUNTU_KUBECONFIG_PATH),
+            ca=ca,
+            server=server,
+            user="ubuntu",
+            token=credentials.get("client_token"),
+        )
+        # Create K8s config in the default location for root.
+        kubernetes_snaps.create_kubeconfig(
+            dest=str(ROOT_KUBECONFIG_PATH),
+            ca=ca,
+            server=server,
+            user="root",
+            token=credentials.get("client_token"),
+        )
+        # Create K8s config for kubelet and kube-proxy.
+        kubernetes_snaps.create_kubeconfig(
+            dest=str(KUBELET_KUBECONFIG_PATH),
+            ca=ca,
+            server=server,
+            user="kubelet",
+            token=credentials.get("kubelet_token"),
+        )
+        kubernetes_snaps.create_kubeconfig(
+            dest=str(KUBEPROXY_KUBECONFIG_PATH),
+            ca=ca,
+            server=server,
+            user="kube-proxy",
+            token=credentials.get("proxy_token"),
+        )
+
+    def _get_unit_number(self) -> int:
+        return int(self.unit.name.split("/")[1])
+
+    def _request_kubelet_and_proxy_credentials(self):
+        """Request authorization for kubelet and kube-proxy."""
+        status.add(MaintenanceStatus("Requesting kubelet and kube-proxy credentials"))
+
+        node_user = f"system:node:{kubernetes_snaps.get_node_name()}"
+        self.kube_control.set_auth_request(node_user)
 
     def reconcile(self, event):
         """Reconcile state changing events."""
         kubernetes_snaps.install(channel=self.model.config["channel"])
+        kubernetes_snaps.configure_services_restart_always()
+        self._request_certificates()
+        self._write_certificates()
+        self._request_kubelet_and_proxy_credentials()
+        self._create_kubeconfigs(event)
+        self._configure_cni()
+        self._configure_container_runtime()
+        self._configure_kernel_parameters()
+        self._configure_kubelet(event)
+        self._configure_kubeproxy(event)
+
+    def _request_certificates(self):
+        """Request client and server certificates."""
+        status.add(MaintenanceStatus("Requesting certificates"))
+        if not self.certificates.relation:
+            status.add(BlockedStatus("Missing integration to certificate authority."))
+            return
+
+        bind_addrs = kubernetes_snaps.get_bind_addresses()
+        common_name = kubernetes_snaps.get_public_address()
+
+        sans = sorted(set([common_name, gethostname()] + bind_addrs))
+
+        self.certificates.request_server_cert(cn=common_name, sans=sans)
+        self.certificates.request_client_cert("system:kubelet")
+
+    def _write_certificates(self):
+        """Write certificates from the certificates relation."""
+        status.add(MaintenanceStatus("Writing certificates"))
+
+        common_name = kubernetes_snaps.get_public_address()
+        ca = self.certificates.ca
+        server_cert = self.certificates.server_certs_map.get(common_name)
+        client_cert = self.certificates.client_certs_map.get("system:kubelet")
+
+        if not ca or not server_cert or not client_cert:
+            status.add(WaitingStatus("Waiting for certificates"))
+            log.info("Certificates are not yet available.")
+            return
+
+        kubernetes_snaps.write_certificates(
+            ca=ca,
+            client_cert=client_cert.cert,
+            client_key=client_cert.key,
+            server_cert=server_cert.cert,
+            server_key=server_cert.key,
+        )
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/tests/data/overlay.yaml
+++ b/tests/data/overlay.yaml
@@ -1,0 +1,5 @@
+description: A minimal two-machine Kubernetes cluster, appropriate for development.
+applications:
+  kubernetes-worker:
+    charm: {{charm}}
+    channel: null

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -2,33 +2,29 @@
 # Copyright 2023 Canonical
 # See LICENSE file for licensing details.
 
-import asyncio
 import logging
-from pathlib import Path
 
 import pytest
-import yaml
 from pytest_operator.plugin import OpsTest
 
-logger = logging.getLogger(__name__)
-
-METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
-APP_NAME = METADATA["name"]
+log = logging.getLogger(__name__)
 
 
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest):
-    """Build the charm-under-test and deploy it together with related charms.
-
-    Assert on the unit status before any relations/configurations take place.
-    """
-    # Build and deploy charm from local source folder
+    """Build kubernetes-worker and deploy with kubernetes-core bundle."""
+    log.info("Building charm")
     charm = await ops_test.build_charm(".")
 
-    # Deploy the charm and wait for active/idle status
-    await asyncio.gather(
-        ops_test.model.deploy(charm, application_name=APP_NAME),
-        ops_test.model.wait_for_idle(
-            apps=[APP_NAME], status="active", raise_on_blocked=True, timeout=1000
-        ),
+    bundle, *overlays = await ops_test.async_render_bundles(
+        ops_test.Bundle("kubernetes-core", channel="edge"), "tests/data/overlay.yaml", charm=charm
     )
+
+    log.info("Deploying bundle")
+    cmd = ["juju", "deploy", "-m", ops_test.model_full_name, bundle]
+    for overlay in overlays:
+        cmd += ["--overlay", overlay]
+    rc, stdout, stderr = await ops_test.run(*cmd)
+    assert rc == 0, f"Bundle deploy failed: {(stderr or stdout).strip()}"
+
+    await ops_test.model.wait_for_idle(status="active", timeout=60 * 60)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,60 @@
+import contextlib
+import unittest.mock as mock
+
+import ops.testing
+import pytest
+from charm import KubernetesWorkerCharm
+from ops.testing import Harness
+
+ops.testing.SIMULATE_CAN_CONNECT = True
+
+MARKERS_AND_MOCKS = {
+    "_check_kubecontrol_integration": "skip_check_kubecontrol_integration",
+    "_request_certificates": "skip_request_certificates",
+    "_write_certificates": "skip_write_certificates",
+    "_request_kubelet_and_proxy_credentials": "skip_request_kubelet_and_proxy_credentials",
+    "_create_kubeconfigs": "skip_create_kubeconfigs",
+    "_configure_cni": "skip_configure_cni",
+    "_configure_container_runtime": "skip_configure_container_runtime",
+    "_configure_kernel_parameters": "skip_configure_kernel_parameters",
+    "_configure_kubelet": "skip_configure_kubelet",
+    "_configure_kubeproxy": "skip_configure_kubeproxy",
+}
+
+
+def pytest_configure(config):
+    for method, marker in MARKERS_AND_MOCKS.items():
+        description = f"Mark tests which do not mock out {method}"
+        config.addinivalue_line("markers", f"{marker}: {description}")
+
+
+@pytest.fixture
+def harness():
+    harness = Harness(KubernetesWorkerCharm)
+    try:
+        harness.add_network("10.0.0.10", endpoint="kube-control")
+        yield harness
+    finally:
+        harness.cleanup()
+
+
+@pytest.fixture
+def charm_environment(request, harness: Harness[KubernetesWorkerCharm]):
+    """Create a charm with mocked methods.
+
+    This fixture utilizes ExitStack to dynamically mock methods in the Kubernetes Worker Charm,
+    using the request markers defined in the `pytest_configure` method.
+    """
+    with contextlib.ExitStack() as stack:
+        mocks = {}
+        for method, marker in MARKERS_AND_MOCKS.items():
+            if marker not in request.keywords:
+                mock_method = mock.MagicMock()
+                stack.enter_context(
+                    mock.patch(f"charm.KubernetesWorkerCharm.{method}", mock_method)
+                )
+                mocks[method] = mock_method
+        with mock.patch("charm.kubernetes_snaps", autospec=True) as mock_kubernetes_snaps:
+            mocks["kubernetes_snaps"] = mock_kubernetes_snaps
+            harness.begin_with_initial_hooks()
+            yield (harness.charm, mocks)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -3,22 +3,249 @@
 #
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
-import unittest
-from unittest.mock import patch
+from typing import Mapping, Tuple
+from unittest.mock import MagicMock, PropertyMock, call, patch
 
 import ops
 import ops.testing
+import pytest
 from charm import KubernetesWorkerCharm
+from charms.interface_container_runtime import ContainerRuntimeProvides
+from charms.interface_kubernetes_cni import KubernetesCniProvides
+from ops.interface_tls_certificates import CertificatesRequires
+from ops.testing import Harness
+
+ops.testing.SIMULATE_CAN_CONNECT = True
+
+CharmEnvironment = Tuple[KubernetesWorkerCharm, Mapping[str, MagicMock]]
 
 
-class TestCharm(unittest.TestCase):
-    def setUp(self):
-        self.harness = ops.testing.Harness(KubernetesWorkerCharm)
-        self.addCleanup(self.harness.cleanup)
+@pytest.mark.parametrize(
+    "evaluation,result",
+    [
+        pytest.param("", True, id="Integration ready"),
+        pytest.param("Waiting", False, id="Integration not ready"),
+    ],
+)
+@pytest.mark.skip_check_kubecontrol_integration
+def test__check_kubecontrol_integration(
+    charm_environment: CharmEnvironment, evaluation: str, result: bool
+):
+    charm, _ = charm_environment
+    with patch.object(charm.kube_control, "evaluate_relation") as mock_evaluate:
+        mock_event = MagicMock()
+        mock_evaluate.return_value = evaluation
+        result = charm._check_kubecontrol_integration(mock_event)
+        assert result is result
 
-    @patch("charms.kubernetes_snaps.install")
-    def test_start(self, kubernetes_snaps_install):
-        self.harness.begin_with_initial_hooks()
 
-        kubernetes_snaps_install.assert_called()
-        self.assertEqual(self.harness.model.unit.status, ops.ActiveStatus())
+@pytest.mark.parametrize(
+    "registry,hash",
+    [
+        pytest.param(
+            "myregistry.com",
+            "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
+            id="Registry available",
+        ),
+        pytest.param(None, None, id="Integration not ready"),
+    ],
+)
+@pytest.mark.skip_configure_cni
+def test__configure_cni(
+    harness: Harness[KubernetesWorkerCharm],
+    charm_environment: CharmEnvironment,
+    registry: str,
+    hash: str,
+):
+    charm, _ = charm_environment
+    with patch.object(charm.kube_control, "get_registry_location") as mock_get_registry:
+        with patch("charms.interface_kubernetes_cni.hash_file") as mock_hash:
+            cni_relation_id = harness.add_relation("cni", "calico")
+            mock_hash.return_value = hash
+            harness.add_relation_unit(cni_relation_id, "calico/0")
+            mock_get_registry.return_value = registry
+            charm._configure_cni()
+            relation_data = harness.get_relation_data(cni_relation_id, "kubernetes-worker/0")
+            assert relation_data.get("image-registry", None) == registry
+            assert relation_data.get("kubeconfig-hash") == hash
+
+
+@pytest.mark.parametrize(
+    "registry,image",
+    [
+        pytest.param(
+            "myregistry.com",
+            "myregistry.com/pause:3.9",
+            id="Registry available",
+        ),
+        pytest.param(None, None, id="Integration not ready"),
+    ],
+)
+@pytest.mark.skip_configure_container_runtime
+def test__configure_container_runtime(
+    harness: Harness[KubernetesWorkerCharm],
+    charm_environment: CharmEnvironment,
+    registry: str,
+    image: str,
+):
+    charm, mocks = charm_environment
+    mock_k8s_snaps = mocks["kubernetes_snaps"]
+    with patch.object(charm.kube_control, "get_registry_location") as mock_get_registry:
+        mock_k8s_snaps.get_sandbox_image.return_value = image
+        cri_relation_id = harness.add_relation("container-runtime", "containerd")
+        harness.add_relation_unit(cri_relation_id, "containerd/0")
+        mock_get_registry.return_value = registry
+        charm._configure_container_runtime()
+        relation_data = harness.get_relation_data(cri_relation_id, "kubernetes-worker/0")
+        assert relation_data.get("sandbox_image", None) == image
+
+
+@pytest.mark.skip_configure_kernel_parameters
+def test__configure_kernel_parameters(charm_environment: CharmEnvironment):
+    charm, mocks = charm_environment
+    mock_k8s_snaps = mocks["kubernetes_snaps"]
+    charm._configure_kernel_parameters()
+    mock_k8s_snaps.configure_kernel_parameters.assert_called_with(
+        {
+            "net.ipv4.conf.all.forwarding": 1,
+            "net.ipv4.conf.all.rp_filter": 1,
+            "net.ipv4.neigh.default.gc_thresh1": 128,
+            "net.ipv4.neigh.default.gc_thresh2": 28672,
+            "net.ipv4.neigh.default.gc_thresh3": 32768,
+            "net.ipv6.neigh.default.gc_thresh1": 128,
+            "net.ipv6.neigh.default.gc_thresh2": 28672,
+            "net.ipv6.neigh.default.gc_thresh3": 32768,
+            "fs.inotify.max_user_instances": 8192,
+            "fs.inotify.max_user_watches": 1048576,
+            "kernel.panic": 10,
+            "kernel.panic_on_oops": 1,
+            "vm.overcommit_memory": 1,
+        }
+    )
+
+
+@pytest.mark.skip_configure_kubelet
+def test__configure_kubelet(charm_environment: CharmEnvironment):
+    charm, mocks = charm_environment
+    mock_event = MagicMock()
+
+    mocks["_check_kubecontrol_integration"].return_value = True
+    dns_config = {
+        "port": 53,
+        "domain": "cluster.local",
+        "sdn-ip": "10.0.0.10",
+        "enable-kube-dns": True,
+    }
+
+    with patch.multiple(
+        charm.kube_control,
+        get_dns=MagicMock(return_value=dns_config),
+        get_registry_location=MagicMock(return_value="myregistry.com"),
+    ):
+        with patch.object(
+            ContainerRuntimeProvides,
+            "socket",
+            new_callable=PropertyMock,
+            return_value="test_my_socket",
+        ):
+            charm._configure_kubelet(mock_event)
+
+            mocks["kubernetes_snaps"].configure_kubelet.assert_called_with(
+                container_runtime_endpoint="test_my_socket",
+                dns_domain="cluster.local",
+                dns_ip="10.0.0.10",
+                extra_args_config="",
+                extra_config={},
+                has_xcp=False,
+                kubeconfig="/root/cdk/kubeconfig",
+                node_ip="10.0.0.10",
+                registry="myregistry.com",
+                taints=None,
+            )
+
+
+@pytest.mark.skip_configure_kubeproxy
+def test__configure_kubeproxy(charm_environment: CharmEnvironment):
+    charm, mocks = charm_environment
+    mock_event = MagicMock()
+    mocks["_check_kubecontrol_integration"].return_value = True
+    with patch.object(
+        KubernetesCniProvides, "cidr", new_callable=PropertyMock, return_value="192.168.0.0/16"
+    ):
+        charm._configure_kubeproxy(mock_event)
+        mocks["kubernetes_snaps"].configure_kube_proxy.assert_called_with(
+            cluster_cidr="192.168.0.0/16",
+            extra_args_config="",
+            extra_config={},
+            kubeconfig="/root/cdk/kubeproxyconfig",
+        )
+
+
+@pytest.mark.skip_create_kubeconfigs
+def test__create_kubeconfigs(charm_environment: CharmEnvironment):
+    charm, mocks = charm_environment
+    mock_event = MagicMock()
+
+    auth_credentials = {
+        "user": "foo",
+        "kubelet_token": "test_kubelet_token",
+        "proxy_token": "test_kubeproxy_token",
+        "client_token": "test_client_token",
+    }
+
+    with patch.object(
+        CertificatesRequires, "ca", new_callable=PropertyMock, return_value="test_ca"
+    ), patch.object(
+        charm.kube_control, "get_auth_credentials", return_value=auth_credentials
+    ), patch.object(
+        charm.kube_control, "get_api_endpoints", return_value=["10.0.0.10", "10.1.1.10"]
+    ):
+        charm._create_kubeconfigs(mock_event)
+
+        calls = [
+            call(
+                dest="/home/ubuntu/.kube/config",
+                ca="test_ca",
+                server="10.0.0.10",
+                user="ubuntu",
+                token="test_client_token",
+            ),
+            call(
+                dest="/root/.kube/config",
+                ca="test_ca",
+                server="10.0.0.10",
+                user="root",
+                token="test_client_token",
+            ),
+            call(
+                dest="/root/cdk/kubeconfig",
+                ca="test_ca",
+                server="10.0.0.10",
+                user="kubelet",
+                token="test_kubelet_token",
+            ),
+            call(
+                dest="/root/cdk/kubeproxyconfig",
+                ca="test_ca",
+                server="10.0.0.10",
+                user="kube-proxy",
+                token="test_kubeproxy_token",
+            ),
+        ]
+
+        mocks["kubernetes_snaps"].create_kubeconfig.assert_has_calls(calls)
+
+
+def test__get_unit_number(charm_environment: CharmEnvironment):
+    charm, _ = charm_environment
+    result = charm._get_unit_number()
+    assert result == 0
+
+
+@pytest.mark.skip_request_kubelet_and_proxy_credentials
+def test__request_kubelet_and_proxy_credentials(charm_environment: CharmEnvironment):
+    charm, mocks = charm_environment
+    with patch.object(charm.kube_control, "set_auth_request") as mock_set_auth:
+        mocks["kubernetes_snaps"].get_node_name.return_value = "foo"
+        charm._request_kubelet_and_proxy_credentials()
+        mock_set_auth.assert_called_with("system:node:foo")


### PR DESCRIPTION
## Summary
This pull request is aimed at implementing the necessary integrations to align the Kubernetes Worker charm with the latest updates in the Kubernetes Control Plane charm.

## Changes
- Implemented the Certificates integration.
- Implemented the `kube-control` integration.
- Configured the `container-runtime` integration.
- Set up the CNI integration.
- Configured `kubelet` and `kube-proxy`.
- Added unit testing with dynamic mocking.
- Added integration tests.