### PR TITLE
Add `cluster` name label

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -236,7 +236,10 @@ class KubernetesWorkerCharm(ops.CharmBase):
                 "static_configs": [
                     {
                         "targets": [config.target],
-                        "labels": {"node": kubernetes_snaps.get_node_name()},
+                        "labels": {
+                            "node": kubernetes_snaps.get_node_name(),
+                            "cluster": self.model.name,
+                        },
                     }
                 ],
                 "relabel_configs": config.relabel_configs,


### PR DESCRIPTION
## Changes
The dashboard expect to use the `cluster` label for a couple of dashboards panel. This PR includes the correct label.