### PR TITLE
[LP#2046508] Set application workload version based on the version of kubelet

### DIFF
--- a/tests/integration/test_k8s_worker_charm.py
+++ b/tests/integration/test_k8s_worker_charm.py
@@ -51,4 +51,4 @@ def test_status(ops_test):
     worker_app = ops_test.model.applications["kubernetes-worker"]
     k8s_version_str = worker_app.data["workload-version"]
     assert k8s_version_str, "Workload version is unset"
-    assert tuple(int(i) for i in k8s_version_str.split(".")[:2]) >= 1.26
+    assert tuple(int(i) for i in k8s_version_str.split(".")[:2]) >= (1, 26)

--- a/tests/integration/test_k8s_worker_charm.py
+++ b/tests/integration/test_k8s_worker_charm.py
@@ -45,3 +45,10 @@ async def test_build_and_deploy(ops_test: OpsTest):
     assert rc == 0, f"Bundle deploy failed: {(stderr or stdout).strip()}"
 
     await ops_test.model.wait_for_idle(status="active", timeout=60 * 60)
+
+
+def test_status(ops_test):
+    worker_app = ops_test.model.applications["kubernetes-worker"]
+    k8s_version_str = worker_app.data["workload-version"]
+    assert k8s_version_str, "Workload version is unset"
+    assert tuple(int(i) for i in k8s_version_str.split(".")[:2]) >= 1.26


### PR DESCRIPTION
[LP#2046508](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2046508)

Some tests of charmed-kubernetes require the application workload status be set on the units in order to run correctly.  Also it's surely a very nice bonus at a glance to know which version of the snaps are installed on the units