### PR TITLE
enforce juju >= 3.1

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -14,10 +14,9 @@ description: |
   a pluggable infrastructure. Self healing in that it will automatically
   restart and place containers on healthy nodes if a node ever goes away.
 docs: https://discourse.charmhub.io/t/kubernetes-worker-docs-index/6104
-series:
-  - jammy
-  - focal
 subordinate: false
+assumes:
+  - juju >= 3.1
 peers:
   coordinator:
     # LP:2049953 needed for upgrading from < 1.29


### PR DESCRIPTION
[LP:2051857](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/2051857)

Ensure this charm only deploys in juju 3.1+ environments.

FYI to reviewers: `series` and `assumes` metadata keys are mutually exclusive.  We can safely drop `series` here since that is now controlled by charmcraft.yaml's builds-on / runs-on directives.