### PR TITLE
Handle unready relations with status.on_error

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -96,7 +96,9 @@ class KubernetesWorkerCharm(ops.CharmBase):
         evaluation = self.kube_control.evaluate_relation(event)
         if evaluation:
             current_status = (
-                WaitingStatus(evaluation) if "Waiting" in evaluation else ops.BlockedStatus(evaluation)
+                WaitingStatus(evaluation)
+                if "Waiting" in evaluation
+                else ops.BlockedStatus(evaluation)
             )
             status.add(current_status)
             return False
@@ -209,9 +211,9 @@ class KubernetesWorkerCharm(ops.CharmBase):
                 "ingress_uid": "101",
                 "juju_application": self.app.name,
                 "ssl_chain_completion": self.config["ingress-ssl-chain-completion"],
-                "use_forwarded_headers": "true"
-                if self.config["ingress-use-forwarded-headers"]
-                else "false",
+                "use_forwarded_headers": (
+                    "true" if self.config["ingress-use-forwarded-headers"] else "false"
+                ),
             }
 
             ssl_cert = self.config["ingress-default-ssl-certificate"]


### PR DESCRIPTION
Let's catch reconcile errors as they happen rather than let than the charm go into error


These changes aren't required to port back to release_1.29