### PR TITLE
Integrate with AWS cloud to appropriately tag worker instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__/
 *.py[cod]
 .idea
 .vscode/
+cni-plugins-*.tar.gz

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -33,9 +33,6 @@ provides:
 requires:
   aws:
     interface: aws-integration
-    description: |
-      [Deprecated] only necessary for upgrades from 1.28 and can be removed after the upgrade
-      There's no need to relate if this is a fresh deployment
   certificates:
     interface: tls-certificates
   kube-control:

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,6 @@ jinja2
 ops >= 2.2.0
 ops.interface_kube_control @ git+https://github.com/juju-solutions/interface-kube-control#subdirectory=ops
 ops.interface_tls_certificates @ git+https://github.com/juju-solutions/interface-tls-certificates#subdirectory=ops
-ops.interface_aws @ git+https://github.com/juju-solutions/interface-aws-integration@KU-437/aws-ops-integration#subdirectory=ops
+ops.interface_aws @ git+https://github.com/juju-solutions/interface-aws-integration@main#subdirectory=ops
 pydantic==1.*
 tenacity

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,6 @@ jinja2
 ops >= 2.2.0
 ops.interface_kube_control @ git+https://github.com/juju-solutions/interface-kube-control#subdirectory=ops
 ops.interface_tls_certificates @ git+https://github.com/juju-solutions/interface-tls-certificates#subdirectory=ops
+ops.interface_aws @ git+https://github.com/juju-solutions/interface-aws-integration@KU-437/aws-ops-integration#subdirectory=ops
 pydantic==1.*
 tenacity

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,6 @@ jinja2
 ops >= 2.2.0
 ops.interface_kube_control @ git+https://github.com/juju-solutions/interface-kube-control#subdirectory=ops
 ops.interface_tls_certificates @ git+https://github.com/juju-solutions/interface-tls-certificates#subdirectory=ops
-ops.interface_aws @ git+https://github.com/juju-solutions/interface-aws-integration@main#subdirectory=ops
+ops.interface_aws @ git+https://github.com/juju-solutions/interface-aws-integration#subdirectory=ops
 pydantic==1.*
 tenacity

--- a/src/charm.py
+++ b/src/charm.py
@@ -24,8 +24,8 @@ from charms.interface_kubernetes_cni import KubernetesCniProvides
 from charms.interface_tokens import TokensRequirer
 from charms.node_base import LabelMaker
 from charms.reconciler import Reconciler
-from cos_integration import COSIntegration
 from cloud_integration import CloudIntegration
+from cos_integration import COSIntegration
 from jinja2 import Environment, FileSystemLoader
 from kubectl import kubectl
 from ops.interface_kube_control import KubeControlRequirer

--- a/src/charm.py
+++ b/src/charm.py
@@ -16,7 +16,6 @@ from subprocess import CalledProcessError
 import charms.contextual_status as status
 import ops
 import yaml
-from cloud_integration import CloudIntegration
 from charms import kubernetes_snaps
 from charms.grafana_agent.v0.cos_agent import COSAgentProvider
 from charms.interface_container_runtime import ContainerRuntimeProvides
@@ -26,6 +25,7 @@ from charms.interface_tokens import TokensRequirer
 from charms.node_base import LabelMaker
 from charms.reconciler import Reconciler
 from cos_integration import COSIntegration
+from cloud_integration import CloudIntegration
 from jinja2 import Environment, FileSystemLoader
 from kubectl import kubectl
 from ops.interface_kube_control import KubeControlRequirer
@@ -45,6 +45,7 @@ class KubernetesWorkerCharm(ops.CharmBase):
     """Charmed Operator for Kubernetes Worker."""
 
     def __init__(self, *args):
+        """Start entrypoint for Kubernetes Worker!"""
         super().__init__(*args)
         self.certificates = CertificatesRequires(self, endpoint="certificates")
         self.cni = KubernetesCniProvides(self, endpoint="cni", default_cni="")
@@ -200,12 +201,15 @@ class KubernetesWorkerCharm(ops.CharmBase):
             ssl_cert = self.config["ingress-default-ssl-certificate"]
             ssl_key = self.config["ingress-default-ssl-key"]
             if ssl_cert and ssl_key:
+                default_cert_option = (
+                    "- --default-ssl-certificate=$(POD_NAMESPACE)/default-ssl-certificate"
+                )
                 context.update(
                     {
                         "default_ssl_certificate": b64encode(ssl_cert.encode("utf-8")).decode(
                             "utf-8"
                         ),
-                        "default_ssl_certificate_option": "- --default-ssl-certificate=$(POD_NAMESPACE)/default-ssl-certificate",
+                        "default_ssl_certificate_option": default_cert_option,
                         "default_ssl_key": b64encode(ssl_key.encode("utf-8")).decode("utf-8"),
                     }
                 )
@@ -305,6 +309,7 @@ class KubernetesWorkerCharm(ops.CharmBase):
 
     @status.on_error(ops.WaitingStatus("Waiting for cluster name"))
     def get_cluster_name(self) -> str:
+        """Get the cluster name from the kube-control relation."""
         assert self.kube_control.is_ready
         return self.kube_control.get_cluster_tag()
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -382,7 +382,7 @@ class KubernetesWorkerCharm(ops.CharmBase):
         self._configure_kubeproxy(event)
         self._configure_nginx_ingress_controller()
         self._configure_labels()
-        self.cloud_integration.integrate()
+        self.cloud_integration.integrate(event)
 
     def _request_certificates(self):
         """Request client and server certificates."""

--- a/src/cloud_integration.py
+++ b/src/cloud_integration.py
@@ -1,0 +1,75 @@
+import logging
+
+import charms.contextual_status as status
+import ops
+from ops.interface_aws.requires import AWSIntegrationRequires
+
+log = logging.getLogger(__name__)
+
+
+class CloudIntegration:
+    """Utility class that handles the integration with clouds for Charmed Kubernetes.
+
+    This class provides methods to configure instance tags and roles for control-plane
+    units
+
+    Attributes:
+        charm (CharmBase): Reference to the base charm instance.
+        aws (AWSIntegrationRequires): Reference to relation integration
+        gcp (GCPIntegrationRequires): Reference to relation integration
+        azure (AzureIntegrationRequires): Reference to relation integration
+    """
+
+    def __init__(self, charm: ops.CharmBase) -> None:
+        self.charm = charm
+        self.aws = AWSIntegrationRequires(charm)
+        self.gcp = None # GCPIntegrationRequires(charm)
+        self.azure = None # AzureIntegrationRequires(charm)
+
+    def integrate(self):
+        """Request tags and permissions for a control-plane node."""
+        cluster_tag = self.charm.get_cluster_name()
+        cloud_name = self.charm.get_cloud_name()
+        cloud_support = {"aws": self.aws,}
+        
+        if not (cloud := cloud_support.get(cloud_name)):
+            log.error("Skipping Cloud integration: unsupported cloud %s", )
+
+        if not cloud.relation:
+            log.info("Skipping Cloud integration: Needs an active %s relation to integrate.", cloud_name)
+            return
+
+        status.add(ops.MaintenanceStatus(f"Integrate with {cloud}"))
+        if cloud_name == "aws":
+            cloud.tag_instance(
+                {
+                    f"kubernetes.io/cluster/{cluster_tag}": "owned",
+                }
+            )
+            cloud.tag_instance_security_group(
+                {
+                    f"kubernetes.io/cluster/{cluster_tag}": "owned",
+                }
+            )
+            cloud.tag_instance_subnet(
+                {
+                    f"kubernetes.io/cluster/{cluster_tag}": "owned",
+                }
+            )
+            cloud.enable_object_storage_management(["kubernetes-*"])
+        elif cloud_name == "gcp":
+            cloud.tag_instance(
+                {
+                    "k8s-io-cluster-name": cluster_tag,
+                }
+            )
+            cloud.enable_object_storage_management()
+        elif cloud_name == "azure":
+            cloud.tag_instance(
+                {
+                    "k8s-io-cluster-name": cluster_tag,
+                }
+            )
+            cloud.enable_object_storage_management()
+        cloud.enable_instance_inspection()
+        cloud.enable_dns_management()

--- a/src/cloud_integration.py
+++ b/src/cloud_integration.py
@@ -44,6 +44,7 @@ class CloudIntegration:
             log.error(
                 "Skipping Cloud integration: unsupported cloud %s",
             )
+            return
 
         if not cloud.relation:
             log.info(

--- a/src/cloud_integration.py
+++ b/src/cloud_integration.py
@@ -1,3 +1,8 @@
+# Copyright 2024 Canonical
+# See LICENSE file for licensing details.
+
+"""Cloud Integration for Charmed Kubernetes Worker."""
+
 import logging
 
 import charms.contextual_status as status
@@ -21,22 +26,29 @@ class CloudIntegration:
     """
 
     def __init__(self, charm: ops.CharmBase) -> None:
+        """Integrate with all possible clouds."""
         self.charm = charm
         self.aws = AWSIntegrationRequires(charm)
-        self.gcp = None # GCPIntegrationRequires(charm)
-        self.azure = None # AzureIntegrationRequires(charm)
+        self.gcp = None  # GCPIntegrationRequires(charm)
+        self.azure = None  # AzureIntegrationRequires(charm)
 
     def integrate(self):
         """Request tags and permissions for a control-plane node."""
         cluster_tag = self.charm.get_cluster_name()
         cloud_name = self.charm.get_cloud_name()
-        cloud_support = {"aws": self.aws,}
-        
+        cloud_support = {
+            "aws": self.aws,
+        }
+
         if not (cloud := cloud_support.get(cloud_name)):
-            log.error("Skipping Cloud integration: unsupported cloud %s", )
+            log.error(
+                "Skipping Cloud integration: unsupported cloud %s",
+            )
 
         if not cloud.relation:
-            log.info("Skipping Cloud integration: Needs an active %s relation to integrate.", cloud_name)
+            log.info(
+                "Skipping Cloud integration: Needs an active %s relation to integrate.", cloud_name
+            )
             return
 
         status.add(ops.MaintenanceStatus(f"Integrate with {cloud}"))

--- a/src/cloud_integration.py
+++ b/src/cloud_integration.py
@@ -32,7 +32,8 @@ class CloudIntegration:
         self.gcp = None  # GCPIntegrationRequires(charm)
         self.azure = None  # AzureIntegrationRequires(charm)
 
-    def integrate(self):
+    @status.on_error(ops.WaitingStatus("Waiting for cloud-integration"))
+    def integrate(self, event: ops.EventBase):
         """Request tags and permissions for a control-plane node."""
         cluster_tag = self.charm.get_cluster_name()
         cloud_name = self.charm.get_cloud_name()
@@ -86,3 +87,4 @@ class CloudIntegration:
             cloud.enable_object_storage_management()
         cloud.enable_instance_inspection()
         cloud.enable_dns_management()
+        assert cloud.evaluate_relation(event) is None


### PR DESCRIPTION
Adds `cloud_integration.py` to prepare for all clouds Charmed-Kubernetes must relate to -- starting with AWS