### PR TITLE
set default snap channel to edge on main branch

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 options:
   channel:
     type: string
-    default: "1.28/edge"
+    default: "latest/edge"
     description: |
       Snap channel to install Kubernetes worker services from
   ingress:


### PR DESCRIPTION
we pin this config on the release_1.xx branches; we should let it track edge on the main branch.