### PR TITLE
Implement an HttpProvides for the ingress-proxy interface

### DIFF
--- a/.github/workflows/naming-lint-unit.yaml
+++ b/.github/workflows/naming-lint-unit.yaml
@@ -4,7 +4,7 @@ on: [pull_request]
 jobs:
   call-inclusive-naming-check:
     name: Inclusive Naming
-    uses: canonical-web-and-design/Inclusive-naming/.github/workflows/woke.yaml@main
+    uses: canonical/inclusive-naming/.github/workflows/woke.yaml@main
     with:
       fail-on-error: "true"
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -30,6 +30,8 @@ provides:
     scope: container
   cos-agent:
     interface: cos_agent
+  ingress-proxy:
+    interface: http
 requires:
   aws:
     interface: aws-integration

--- a/src/charm.py
+++ b/src/charm.py
@@ -26,6 +26,7 @@ from charms.node_base import LabelMaker
 from charms.reconciler import Reconciler
 from cloud_integration import CloudIntegration
 from cos_integration import COSIntegration
+from http_provides import HttpProvides
 from jinja2 import Environment, FileSystemLoader
 from kubectl import kubectl
 from ops.interface_kube_control import KubeControlRequirer
@@ -64,6 +65,7 @@ class KubernetesWorkerCharm(ops.CharmBase):
             ],
         )
         self.external_cloud_provider = ExternalCloudProvider(self, "kube-control")
+        self.ingress_proxy = HttpProvides(self, "ingress-proxy")
         self.kube_control = KubeControlRequirer(self)
         self.label_maker = LabelMaker(self, kubeconfig_path="/root/.kube/config")
         self.cloud_integration = CloudIntegration(self)
@@ -382,6 +384,7 @@ class KubernetesWorkerCharm(ops.CharmBase):
         self._configure_kubeproxy(event)
         self._configure_nginx_ingress_controller()
         self._configure_labels()
+        self.ingress_proxy.configure(port=80)
         self.cloud_integration.integrate(event)
 
     def _request_certificates(self):

--- a/src/http_provides.py
+++ b/src/http_provides.py
@@ -1,0 +1,71 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""HTTP Provides module."""
+
+import json
+from typing import List, Optional, Union
+
+import ops
+
+
+class HttpProvides:
+    """Provides side of the http interface."""
+
+    def __init__(self, parent: ops.CharmBase, relation: str):
+        self.model = parent.model
+        self.relation_name = relation
+
+    @property
+    def relations(self) -> List[ops.Relation]:
+        """All the relations using this provider."""
+        return self.model.relations.get(self.relation_name) or []
+
+    def get_ingress_address(
+        self, relation: ops.Relation = None
+    ) -> Optional[Union[str, List[str]]]:
+        """Resolve the ingress address from the relation.
+
+        If no relation is provided, we fallback to the first one
+        """
+        if relation is None:
+            relation = self.relations[0]
+        unit_data = relation.data[self.model.unit]
+        return unit_data.get("ingress-address") or unit_data.get("private-address")
+
+    def configure(self, port, private_address=None, hostname=None):
+        """Configure the address(es).
+
+        Private_address and hostname can be None, a single string address/hostname,
+        or a list of addresses and hostnames. Note that if a list is passed,
+        it is assumed both private_address and hostname are either lists or None
+        """
+        for relation in self.relations:
+            ingress_address = self.get_ingress_address(relation)
+            if isinstance(private_address, list) or isinstance(hostname, list):
+                # build 3 lists to zip together that are the same length
+                length = max(len(private_address), len(hostname))
+                p = [port] * length
+                a = private_address + [ingress_address] * (length - len(private_address))
+                h = hostname + [ingress_address] * (length - len(hostname))
+                zipped_list = zip(p, a, h)
+                # now build an array of dictionaries from that in the desired
+                # format for the interface
+                data_list = [
+                    {"hostname": h, "port": p, "private-address": a} for p, a, h in zipped_list
+                ]
+                # for backwards compatibility, we just send a single entry
+                # and have an array of dictionaries in a field of that
+                # entry for the other entries.
+                data = data_list.pop(0)
+                data["extended_data"] = json.dumps(data_list)
+
+                relation.data[self.model.unit].update(data)
+            else:
+                relation.data[self.model.unit].update(
+                    {
+                        "hostname": hostname or ingress_address,
+                        "private-address": private_address or ingress_address,
+                        "port": port,
+                    }
+                )

--- a/src/http_provides.py
+++ b/src/http_provides.py
@@ -66,6 +66,6 @@ class HttpProvides:
                     {
                         "hostname": hostname or ingress_address,
                         "private-address": private_address or ingress_address,
-                        "port": port,
+                        "port": str(port),
                     }
                 )


### PR DESCRIPTION
## Overview
Re-introduce a fix for a gap identified in the 1.29 release of Charmed Kubernetes where the kubernetes-worker cannot be related to other applications via their http interface.


## Details
Re-implements in ops what was removed when the `ingress-proxy` relation was removed during the ops uplift. 

@dnegreira, Help me evaluate this fix will resolve the missing ingress-proxy relation