### PR TITLE
LP#2065251 Worker units stuck awaiting COS tokens

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -357,6 +357,7 @@ class KubernetesWorkerCharm(ops.CharmBase):
         node_user = f"system:node:{self.get_node_name()}"
         self.kube_control.set_auth_request(node_user)
 
+    @status.on_error(ops.WaitingStatus("Waiting for COS token"))
     def _request_monitoring_token(self, event):
         status.add(ops.MaintenanceStatus("Requesting COS token"))
         if not self._check_tokens_integration(event):
@@ -364,6 +365,7 @@ class KubernetesWorkerCharm(ops.CharmBase):
 
         cos_user = f"system:cos:{self.get_node_name()}"
         self.tokens.request_token(cos_user, OBSERVABILITY_GROUP)
+        assert not self.tokens.in_flight_requests()
 
     def reconcile(self, event):
         """Reconcile state changing events."""


### PR DESCRIPTION
## Overview
Prevent the charm from being set as reconciled if there are token requests that are still not yet fulfilled.
## Further Information
This change has been tested in upgrades and when adding units. [Model status](https://paste.ubuntu.com/p/myGXwFst88/)