### PR TITLE
Don't use a status context on actions

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -3,8 +3,9 @@ import unittest.mock as mock
 
 import ops.testing
 import pytest
-from charm import KubernetesWorkerCharm
 from ops.testing import Harness
+
+from charm import KubernetesWorkerCharm
 
 ops.testing.SIMULATE_CAN_CONNECT = True
 

--- a/tests/unit/test_actions.py
+++ b/tests/unit/test_actions.py
@@ -25,11 +25,17 @@ def test_upgrade_action_success(upgrade_snaps: mock.Mock, harness):
     assert harness.model.unit.status == ops.BlockedStatus("reconciled")
 
 
-@mock.patch.object(
-    kubernetes_snaps, "upgrade_snaps", side_effect=Exception("snap upgrade failed")
-)
+@mock.patch.object(kubernetes_snaps, "upgrade_snaps")
 def test_upgrade_action_fails(upgrade_snaps: mock.Mock, harness):
     """Verify that the upgrade action runs the upgrade_snap method and reconciles."""
+
+    def mock_upgrade(channel, event):
+        assert channel == "latest/edge"
+        status.add(ops.BlockedStatus("snap-upgrade-failed"))
+        event.fail("snap upgrade failed")
+
+    upgrade_snaps.side_effect = mock_upgrade
+
     harness.begin_with_initial_hooks()
     harness.model.unit.status = ops.model.BlockedStatus("pre-test")
     with mock.patch.object(harness.charm.reconciler, "reconcile_function") as mocked_reconciler:
@@ -38,4 +44,4 @@ def test_upgrade_action_fails(upgrade_snaps: mock.Mock, harness):
     upgrade_snaps.assert_called_once()
     mocked_reconciler.assert_not_called()
     assert action_err.value.message == "snap upgrade failed"
-    assert harness.model.unit.status == ops.BlockedStatus("pre-test")
+    assert harness.model.unit.status == ops.BlockedStatus("snap-upgrade-failed")

--- a/tests/unit/test_actions.py
+++ b/tests/unit/test_actions.py
@@ -1,0 +1,41 @@
+from unittest import mock
+
+import charms.contextual_status as status
+import ops
+import pytest
+
+from charm import kubernetes_snaps
+
+
+@mock.patch.object(kubernetes_snaps, "upgrade_snaps")
+def test_upgrade_action_success(upgrade_snaps: mock.Mock, harness):
+    """Verify that the upgrade action runs the upgrade_snap method and reconciles."""
+
+    def mock_reconciler(_):
+        status.add(ops.BlockedStatus("reconciled"))
+
+    harness.begin_with_initial_hooks()
+    harness.model.unit.status = ops.model.BlockedStatus("pre-test")
+    with mock.patch.object(
+        harness.charm.reconciler, "reconcile_function", side_effect=mock_reconciler
+    ) as mocked_reconciler:
+        harness.run_action("upgrade")
+    upgrade_snaps.assert_called_once()
+    mocked_reconciler.assert_called_once()
+    assert harness.model.unit.status == ops.BlockedStatus("reconciled")
+
+
+@mock.patch.object(
+    kubernetes_snaps, "upgrade_snaps", side_effect=Exception("snap upgrade failed")
+)
+def test_upgrade_action_fails(upgrade_snaps: mock.Mock, harness):
+    """Verify that the upgrade action runs the upgrade_snap method and reconciles."""
+    harness.begin_with_initial_hooks()
+    harness.model.unit.status = ops.model.BlockedStatus("pre-test")
+    with mock.patch.object(harness.charm.reconciler, "reconcile_function") as mocked_reconciler:
+        with pytest.raises(ops.testing.ActionFailed) as action_err:
+            harness.run_action("upgrade")
+    upgrade_snaps.assert_called_once()
+    mocked_reconciler.assert_not_called()
+    assert action_err.value.message == "snap upgrade failed"
+    assert harness.model.unit.status == ops.BlockedStatus("pre-test")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -9,11 +9,12 @@ from unittest.mock import MagicMock, PropertyMock, call, patch
 import ops
 import ops.testing
 import pytest
-from charm import KubernetesWorkerCharm
 from charms.interface_container_runtime import ContainerRuntimeProvides
 from charms.interface_kubernetes_cni import KubernetesCniProvides
 from ops.interface_tls_certificates import CertificatesRequires
 from ops.testing import Harness
+
+from charm import KubernetesWorkerCharm
 
 ops.testing.SIMULATE_CAN_CONNECT = True
 

--- a/tox.ini
+++ b/tox.ini
@@ -26,26 +26,21 @@ pass_env =
 
 [testenv:format]
 description = Apply coding style standards to code
-deps =
-    black
-    ruff
-commands =
-    black {[vars]all_path}
-    ruff --fix {[vars]all_path}
+deps = ruff
+commands = ruff check --fix {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 deps =
-    black
-    ruff
     codespell
+    tomli
+    ruff
 commands =
     # if this charm owns a lib, uncomment "lib_path" variable
     # and uncomment the following line
     # codespell {[vars]lib_path}
     codespell {tox_root}
-    ruff {[vars]all_path}
-    black --check --diff {[vars]all_path}
+    ruff check {[vars]all_path}
 
 [testenv:unit]
 description = Run unit tests


### PR DESCRIPTION
### Overview
Addresses [LP#2077189](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/2077189)

Charm actions shouldn't use `status.context` because all that happens is that it ignores all exceptions and sets the unit status to Active/Idle

But the `upgrade` action has to use it since `kubernetes_snaps` depends on using the `status.add` method, so we have to carefully manage it

### Details
* A bunch of files are touched b/c `ruff` wants to test things harder.  
* The LP bug was discovered by @pedrofragola -- thanks so much
* But it turns out that using the `status.context` wipes out the charm's unit.status
   *  if `status.context` is used outside of a reconciled action, then we must run the reconciler again
   * MOST IMPORTANTLY -- we don't need WIPE out a WaitingStatus or BlockedStatus just because we ran an action. That's kinda bonkers
