### PR TITLE
Bump ingress-nginx for 1.31

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -186,7 +186,7 @@ class KubernetesWorkerCharm(ops.CharmBase):
             image = self.config["nginx-image"]
             if image == "" or image == "auto":
                 registry = self.kube_control.get_registry_location() or "registry.k8s.io"
-                image = f"{registry}/ingress-nginx/controller:v1.6.4"
+                image = f"{registry}/ingress-nginx/controller:v1.11.2"
 
             context = {
                 "daemonset_api_version": "apps/v1",


### PR DESCRIPTION
Updated for supported versions: 1.30, 1.29, 1.28, 1.27, 1.26
https://github.com/kubernetes/ingress-nginx/blob/main/README.md#readme

Also confirmed it works with 1.31