### PR TITLE
Pin config to 1.32/stable snaps and tests to 1.32/stable charms

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 options:
   channel:
     type: string
-    default: "latest/edge"
+    default: "1.32/stable"
     description: |
       Snap channel to install Kubernetes worker services from
   ingress:

--- a/tests/integration/test_k8s_worker_charm.py
+++ b/tests/integration/test_k8s_worker_charm.py
@@ -33,7 +33,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
 
     log.info("Building bundle")
     bundle, *overlays = await ops_test.async_render_bundles(
-        ops_test.Bundle("kubernetes-core", channel="edge"),
+        ops_test.Bundle("kubernetes-core", channel="1.32/stable"),
         Path("tests/data/charm.yaml"),
         arch="amd64",
         charm=charm.resolve(),

--- a/tests/unit/test_actions.py
+++ b/tests/unit/test_actions.py
@@ -30,7 +30,7 @@ def test_upgrade_action_fails(upgrade_snaps: mock.Mock, harness):
     """Verify that the upgrade action runs the upgrade_snap method and reconciles."""
 
     def mock_upgrade(channel, event):
-        assert channel == "latest/edge"
+        assert channel == "1.32/stable"
         status.add(ops.BlockedStatus("snap-upgrade-failed"))
         event.fail("snap upgrade failed")
 


### PR DESCRIPTION
Per [release checklist](https://github.com/charmed-kubernetes/jenkins/blob/main/docs/releases/stable/index.md#pin-snap-channel-on-bundlescharms-in-the-release-branches)

Expect integration tests to fail because 1.32/stable charms don't yet exist