### PR TITLE
config: Add ingress-proxy-real-ip-cidr charm config

### DIFF
--- a/.github/workflows/vsphere-integration.yaml
+++ b/.github/workflows/vsphere-integration.yaml
@@ -47,7 +47,7 @@ jobs:
           mv juju-crashdump-* tmp/ | true
       - name: Upload debug artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-run-artifacts
           path: tmp

--- a/config.yaml
+++ b/config.yaml
@@ -58,6 +58,22 @@ options:
 
       Reference: https://github.com/kubernetes/ingress-nginx/blob/a9c706be12a8be418c49ab1f60a02f52f9b14e55/
       docs/user-guide/nginx-configuration/configmap.md#use-forwarded-headers.
+  ingress-proxy-real-ip-cidr:
+    type: string
+    default: "0.0.0.0/0"
+    description: |
+      If `ingress-use-forwarded-headers` is enabled, `ingress-proxy-real-ip-cidr` defines 
+      the default IP/network address of your external load balancer. Can be a comma-separated 
+      list of CIDR blocks.
+
+      By default NGINX uses the content of the header `X-Forwarded-For` as the source of truth 
+      to get information about the client IP address. This works without issues in L7 if we 
+      configure the setting `ingress-proxy-real-ip-cidr` with the correct information of the IP/network 
+      address of trusted external load balancer.
+
+      References:
+        - https://kubernetes.github.io/ingress-nginx/user-guide/miscellaneous/#source-ip-address
+        - https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#proxy-real-ip-cidr
   kubelet-extra-args:
     type: string
     default: ""

--- a/src/charm.py
+++ b/src/charm.py
@@ -200,6 +200,7 @@ class KubernetesWorkerCharm(ops.CharmBase):
                 "use_forwarded_headers": (
                     "true" if self.config["ingress-use-forwarded-headers"] else "false"
                 ),
+                "proxy_real_ip_cidr": self.config.get("ingress-proxy-real-ip-cidr", "0.0.0.0/0"),
             }
 
             ssl_cert = self.config["ingress-default-ssl-certificate"]

--- a/src/charm.py
+++ b/src/charm.py
@@ -200,6 +200,7 @@ class KubernetesWorkerCharm(ops.CharmBase):
                 "use_forwarded_headers": (
                     "true" if self.config["ingress-use-forwarded-headers"] else "false"
                 ),
+                # NOTE(Hue): The default comes from https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#proxy-real-ip-cidr
                 "proxy_real_ip_cidr": self.config.get("ingress-proxy-real-ip-cidr", "0.0.0.0/0"),
             }
 

--- a/templates/ingress-daemon-set.yaml
+++ b/templates/ingress-daemon-set.yaml
@@ -34,6 +34,7 @@ metadata:
     cdk-{{ juju_application }}-ingress: "true"
 data:
   use-forwarded-headers: "{{ use_forwarded_headers }}"
+  proxy-real-ip-cidr: "{{ proxy_real_ip_cidr }}"
 
 ---
 kind: ConfigMap


### PR DESCRIPTION
### Overview
This PR adds the `ingress-proxy-real-ip-cidr` charm config which is passed to the `proxy-real-ip-cidr` config of the ingress nginx.

Addresses: https://bugs.launchpad.net/charm-kubernetes-worker/+bug/2059912