### PR TITLE
Add charm config to ignore missing CNI, and block when CNI is missing

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,6 +4,12 @@ options:
     default: "latest/edge"
     description: |
       Snap channel to install Kubernetes worker services from
+  ignore-missing-cni:
+    type: boolean
+    default: false
+    description: |
+      If ignore-missing-cni is set to true, the charm will not enter a blocked state if a CNI has not been configured/provided via relation.
+      If ignore-missing-cni is set to false, and a CNI has not been configured/provided via relation, then the charm will enter a blocked state with the message: "Missing CNI relation or config".
   ingress:
     type: boolean
     default: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,18 +1,18 @@
-charm-lib-contextual-status @ git+https://github.com/charmed-kubernetes/charm-lib-contextual-status
 charm-lib-interface-container-runtime @ git+https://github.com/charmed-kubernetes/charm-lib-interface-container-runtime@main
 charm-lib-interface-external-cloud-provider @ git+https://github.com/charmed-kubernetes/charm-lib-interface-external-cloud-provider@main
 charm-lib-interface-kubernetes-cni @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kubernetes-cni@main
 charm-lib-interface-tokens @ git+https://github.com/charmed-kubernetes/charm-lib-interface-tokens@main
 charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps@main
 charm-lib-node-base @ git+https://github.com/charmed-kubernetes/layer-kubernetes-node-base@main#subdirectory=ops
-charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler@main
-ops.interface-kube-control==0.2.0
 ops.interface_tls_certificates @ git+https://github.com/charmed-kubernetes/interface-tls-certificates@main#subdirectory=ops
 ops.interface_aws @ git+https://github.com/charmed-kubernetes/interface-aws-integration@main#subdirectory=ops
 ops.interface_gcp @ git+https://github.com/charmed-kubernetes/interface-gcp-integration@main#subdirectory=ops
 ops.interface_azure @ git+https://github.com/charmed-kubernetes/interface-azure-integration@main#subdirectory=ops
 cosl == 0.0.7
+charms.reconciler == 0.0.0
+charms.contextual-status == 0.0.0
 jinja2 == 3.1.3
 ops == 2.12.0
+ops.interface-kube-control==0.2.0
 pydantic==1.10.15
 tenacity==8.2.3

--- a/src/charm.py
+++ b/src/charm.py
@@ -102,11 +102,12 @@ class KubernetesWorkerCharm(ops.CharmBase):
     @status.on_error(ops.BlockedStatus("Missing CNI Integration"))
     def _configure_cni(self):
         """Configure the CNI integration databag."""
+        ignore_missing_cni = self.model.config["ignore-missing-cni"]
         if not self.cni.default_relation:
-            if self.model.config["ignore-missing-cni"]:
-                log.info("Ignoring missing CNI configuration as per user request.")
-                return
-            raise status.ReconcilerError("CNI relation not established")
+            if not ignore_missing_cni:
+                raise status.ReconcilerError("CNI relation not established")
+            log.info("Ignoring missing CNI configuration as per user request.")
+
         status.add(ops.MaintenanceStatus("Configuring CNI"))
         registry = self.kube_control.get_registry_location()
         self.cni.set_image_registry(registry)

--- a/src/charm.py
+++ b/src/charm.py
@@ -102,7 +102,10 @@ class KubernetesWorkerCharm(ops.CharmBase):
     @status.on_error(ops.BlockedStatus("Missing CNI Integration"))
     def _configure_cni(self):
         """Configure the CNI integration databag."""
-        if not (self.cni and self.cni.default_relation):
+        if not self.cni.default_relation:
+            if self.model.config["ignore-missing-cni"]:
+                log.info("Ignoring missing CNI configuration as per user request.")
+                return
             raise status.ReconcilerError("CNI relation not established")
         status.add(ops.MaintenanceStatus("Configuring CNI"))
         registry = self.kube_control.get_registry_location()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -68,17 +68,19 @@ def test_configure_cni_registry_no_cni(
     harness: Harness[KubernetesWorkerCharm],
     caplog
 ):
-    charm, _ = charm_environment
+    charm, mocks = charm_environment
     harness.disable_hooks()
     with pytest.raises(ReconcilerError) as ie:
         charm._configure_cni()
     assert ie.match("Found expected exception: CNI relation not established")
+    mocks["kubernetes_snaps"].set_default_cni_conf_file.assert_not_called()
 
     harness.update_config({"ignore-missing-cni": True})
     charm._configure_cni()
     infos = [log[2] for log in caplog.record_tuples if log[1] == logging.INFO]
     assert len(infos) == 1, "There should be only one info level log"
     assert ["Ignoring missing CNI configuration as per user request."] == infos
+    mocks["kubernetes_snaps"].set_default_cni_conf_file.assert_called_once_with(None)
 
 
 @pytest.mark.skip_configure_container_runtime


### PR DESCRIPTION
Link to bug: [LP#2009525](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2009525)

Fix regression introduced in 1.29 by losing a feature that existed.
* add's back charm config `ignore-missing-cni`
* blocks if the cni is missing and not intentionally ignored

### Dependent PRs (?)
* https://github.com/charmed-kubernetes/charm-lib-reconciler/pull/5
* https://github.com/charmed-kubernetes/charm-lib-contextual-status/pull/4
* https://github.com/charmed-kubernetes/charm-kubernetes-control-plane/pull/375