### PR TITLE
Prepare patch build for Manual CNI deployments

### DIFF
--- a/.github/workflows/vsphere-integration.yaml
+++ b/.github/workflows/vsphere-integration.yaml
@@ -47,7 +47,7 @@ jobs:
           mv juju-crashdump-* tmp/ | true
       - name: Upload debug artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-run-artifacts
           path: tmp

--- a/config.yaml
+++ b/config.yaml
@@ -4,6 +4,12 @@ options:
     default: "1.31/stable"
     description: |
       Snap channel to install Kubernetes worker services from
+  ignore-missing-cni:
+    type: boolean
+    default: false
+    description: |
+      If ignore-missing-cni is set to true, the charm will not enter a blocked state if a CNI has not been configured/provided via relation.
+      If ignore-missing-cni is set to false, and a CNI has not been configured/provided via relation, then the charm will enter a blocked state with the message: "Missing CNI relation or config".
   ingress:
     type: boolean
     default: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ charm-lib-interface-container-runtime @ git+https://github.com/charmed-kubernete
 charm-lib-interface-external-cloud-provider @ git+https://github.com/charmed-kubernetes/charm-lib-interface-external-cloud-provider@release_1.31
 charm-lib-interface-kubernetes-cni @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kubernetes-cni@release_1.31
 charm-lib-interface-tokens @ git+https://github.com/charmed-kubernetes/charm-lib-interface-tokens@release_1.31
-charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps@release_1.31
+charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps@no-cni/release-1.31
 charm-lib-node-base @ git+https://github.com/charmed-kubernetes/layer-kubernetes-node-base@release_1.31#subdirectory=ops
 charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler@release_1.31
 ops.interface_kube_control @ git+https://github.com/charmed-kubernetes/interface-kube-control@release_1.31#subdirectory=ops

--- a/src/charm.py
+++ b/src/charm.py
@@ -102,8 +102,12 @@ class KubernetesWorkerCharm(ops.CharmBase):
     @status.on_error(ops.BlockedStatus("Missing CNI Integration"))
     def _configure_cni(self):
         """Configure the CNI integration databag."""
-        if not (self.cni and self.cni.default_relation):
-            raise status.ReconcilerError("CNI relation not established")
+        ignore_missing_cni = self.model.config["ignore-missing-cni"]
+        if not self.cni.default_relation:
+            if not ignore_missing_cni:
+                raise status.ReconcilerError("CNI relation not established")
+            log.info("Ignoring missing CNI configuration as per user request.")
+
         status.add(ops.MaintenanceStatus("Configuring CNI"))
         registry = self.kube_control.get_registry_location()
         self.cni.set_image_registry(registry)

--- a/tests/unit/test_actions.py
+++ b/tests/unit/test_actions.py
@@ -30,7 +30,7 @@ def test_upgrade_action_fails(upgrade_snaps: mock.Mock, harness):
     """Verify that the upgrade action runs the upgrade_snap method and reconciles."""
 
     def mock_upgrade(channel, event):
-        assert channel == "latest/edge"
+        assert channel == harness.charm.config["channel"]
         status.add(ops.BlockedStatus("snap-upgrade-failed"))
         event.fail("snap upgrade failed")
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -3,6 +3,7 @@
 #
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
+import logging
 from typing import Mapping, Tuple
 from unittest.mock import MagicMock, PropertyMock, call, patch
 
@@ -63,13 +64,23 @@ def test_configure_cni_registry(
 
 @pytest.mark.skip_configure_cni
 def test_configure_cni_registry_no_cni(
-    charm_environment: CharmEnvironment, harness: Harness[KubernetesWorkerCharm]
+    charm_environment: CharmEnvironment,
+    harness: Harness[KubernetesWorkerCharm],
+    caplog
 ):
-    charm, _ = charm_environment
+    charm, mocks = charm_environment
     harness.disable_hooks()
     with pytest.raises(ReconcilerError) as ie:
         charm._configure_cni()
     assert ie.match("Found expected exception: CNI relation not established")
+    mocks["kubernetes_snaps"].set_default_cni_conf_file.assert_not_called()
+
+    harness.update_config({"ignore-missing-cni": True})
+    charm._configure_cni()
+    infos = [log[2] for log in caplog.record_tuples if log[1] == logging.INFO]
+    assert len(infos) == 1, "There should be only one info level log"
+    assert ["Ignoring missing CNI configuration as per user request."] == infos
+    mocks["kubernetes_snaps"].set_default_cni_conf_file.assert_called_once_with(None)
 
 
 @pytest.mark.skip_configure_container_runtime


### PR DESCRIPTION
### Overview 
Preparing a new channel for testing without a CNI deployed in 1.31 Charmed Kubernetes

### Details
* Apply `ignore-missing-cni` configuration
* Adjustments to engage CI appropriately