### PR TITLE
Ingress address should also be part of the SANS list

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -398,8 +398,10 @@ class KubernetesWorkerCharm(ops.CharmBase):
 
         bind_addrs = kubernetes_snaps.get_bind_addresses()
         common_name = kubernetes_snaps.get_public_address()
+        ingress_ip = kubernetes_snaps.get_ingress_ip()
 
-        sans = sorted(set([common_name, gethostname()] + bind_addrs))
+        sans = sorted(set([common_name, gethostname()] + bind_addrs +
+                          ingress_ip))
 
         self.certificates.request_server_cert(cn=common_name, sans=sans)
         self.certificates.request_client_cert("system:kubelet")


### PR DESCRIPTION
Addresses [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/2109614)

Since the sans addresses will be used  to generate the Subject Alternative Name in the server.crt file, if the ingress address is not present, it can cause access errors in the scenarios where the ingress address is used by other kubernetes services to reach the worker.