### PR TITLE
Pin setuptools used for noble and jammy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ ops == 2.17.1
 ops.interface-kube-control==0.2.0
 pydantic==1.10.15
 tenacity==8.2.3
+setuptools==79.0.1


### PR DESCRIPTION
* pins setuptools used by python 3.10 and 3.12 
* overrides charmcraft 2.x's default of `setuptools-59.6.0`

Similar to:
* https://github.com/charmed-kubernetes/charm-kubernetes-control-plane/pull/385
* https://github.com/charmed-kubernetes/charm-kubernetes-e2e/pull/40
* https://github.com/charmed-kubernetes/charm-calico/pull/119
* https://github.com/charmed-kubernetes/charm-kubeapi-load-balancer/pull/46
* https://github.com/charmed-kubernetes/charm-kube-ovn/pull/60