### PR TITLE
fix: support dual stack kubelet node ip addresses

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -442,12 +442,13 @@ class KubernetesWorkerCharm(ops.CharmBase):
             return True, f"Failed to check {service} status: {e.output.decode('utf-8')}"
 
     def _check_core_services(self, services):
-        for service in services:
-            log.info(f"checking the status of {service}")
-            has_failed, reason = self._service_has_failed(service)
-            if has_failed:
-                status.add(ops.BlockedStatus(f"{service} has failed: {reason}"))
-                return
+        with status.context(self.unit):
+            for service in services:
+                log.info(f"checking the status of {service}")
+                has_failed, reason = self._service_has_failed(service)
+                if has_failed:
+                    status.add(ops.BlockedStatus(f"{service} has failed: {reason}"))
+                    return
 
     def update_status(self, _event):
         """Handle the update status hook event.


### PR DESCRIPTION
To addresss a similar issue as https://github.com/canonical/k8s-snap/issues/1448, this PR suggest changes to update the `--node-ip` flag of kubelet on worker charm to include both ipv4 and ipv6 addresses, if present, which became a Cilium requirement with 1.17. It also checks that the IPs are not unspecified in case of a dual stack environment as per kubelet's requirement. 