### PR TITLE
[release_1.32] fix: `ignore-missing-cni`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,6 +4,12 @@ options:
     default: "1.32/stable"
     description: |
       Snap channel to install Kubernetes worker services from
+  ignore-missing-cni:
+    type: boolean
+    default: false
+    description: |
+      If ignore-missing-cni is set to true, the charm will not enter a blocked state if a CNI has not been configured/provided via relation.
+      If ignore-missing-cni is set to false, and a CNI has not been configured/provided via relation, then the charm will enter a blocked state with the message: "Missing CNI relation or config".
   ingress:
     type: boolean
     default: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,18 +1,18 @@
-charm-lib-contextual-status @ git+https://github.com/charmed-kubernetes/charm-lib-contextual-status
 charm-lib-interface-container-runtime @ git+https://github.com/charmed-kubernetes/charm-lib-interface-container-runtime@release_1.32
 charm-lib-interface-external-cloud-provider @ git+https://github.com/charmed-kubernetes/charm-lib-interface-external-cloud-provider@release_1.32
 charm-lib-interface-kubernetes-cni @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kubernetes-cni@release_1.32
 charm-lib-interface-tokens @ git+https://github.com/charmed-kubernetes/charm-lib-interface-tokens@release_1.32
-charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps@release_1.32
 charm-lib-node-base @ git+https://github.com/charmed-kubernetes/layer-kubernetes-node-base@release_1.32#subdirectory=ops
-charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler@release_1.32
-ops.interface_kube_control == 0.2.0
 ops.interface_tls_certificates @ git+https://github.com/charmed-kubernetes/interface-tls-certificates@release_1.32#subdirectory=ops
 ops.interface_aws @ git+https://github.com/charmed-kubernetes/interface-aws-integration@release_1.32#subdirectory=ops
 ops.interface_gcp @ git+https://github.com/charmed-kubernetes/interface-gcp-integration@release_1.32#subdirectory=ops
 ops.interface_azure @ git+https://github.com/charmed-kubernetes/interface-azure-integration@release_1.32#subdirectory=ops
 cosl == 0.0.7
+charms.contextual-status == 0.0.0
+charms.reconciler == 0.0.0
+charms.kubernetes-snaps == 0.0.0
 jinja2 == 3.1.3
 ops == 2.12.0
+ops.interface_kube_control == 0.2.0
 pydantic==1.10.15
 tenacity==8.2.3

--- a/src/charm.py
+++ b/src/charm.py
@@ -102,8 +102,12 @@ class KubernetesWorkerCharm(ops.CharmBase):
     @status.on_error(ops.BlockedStatus("Missing CNI Integration"))
     def _configure_cni(self):
         """Configure the CNI integration databag."""
-        if not (self.cni and self.cni.default_relation):
-            raise status.ReconcilerError("CNI relation not established")
+        ignore_missing_cni = self.model.config["ignore-missing-cni"]
+        if not self.cni.default_relation:
+            if not ignore_missing_cni:
+                raise status.ReconcilerError("CNI relation not established")
+            log.info("Ignoring missing CNI configuration as per user request.")
+
         status.add(ops.MaintenanceStatus("Configuring CNI"))
         registry = self.kube_control.get_registry_location()
         self.cni.set_image_registry(registry)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -3,6 +3,7 @@
 #
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
+import logging
 from typing import Mapping, Tuple
 from unittest.mock import MagicMock, PropertyMock, call, patch
 
@@ -63,13 +64,23 @@ def test_configure_cni_registry(
 
 @pytest.mark.skip_configure_cni
 def test_configure_cni_registry_no_cni(
-    charm_environment: CharmEnvironment, harness: Harness[KubernetesWorkerCharm]
+    charm_environment: CharmEnvironment,
+    harness: Harness[KubernetesWorkerCharm],
+    caplog
 ):
-    charm, _ = charm_environment
+    charm, mocks = charm_environment
     harness.disable_hooks()
     with pytest.raises(ReconcilerError) as ie:
         charm._configure_cni()
     assert ie.match("Found expected exception: CNI relation not established")
+    mocks["kubernetes_snaps"].set_default_cni_conf_file.assert_not_called()
+
+    harness.update_config({"ignore-missing-cni": True})
+    charm._configure_cni()
+    infos = [log[2] for log in caplog.record_tuples if log[1] == logging.INFO]
+    assert len(infos) == 1, "There should be only one info level log"
+    assert ["Ignoring missing CNI configuration as per user request."] == infos
+    mocks["kubernetes_snaps"].set_default_cni_conf_file.assert_called_once_with(None)
 
 
 @pytest.mark.skip_configure_container_runtime


### PR DESCRIPTION
## Overview
Port the `ignore-missing-cni` to `release_1.32`.