### PR TITLE
[release_1.33] chore: use `charms.kubernetes-snaps` package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ charm-lib-interface-container-runtime @ git+https://github.com/charmed-kubernete
 charm-lib-interface-external-cloud-provider @ git+https://github.com/charmed-kubernetes/charm-lib-interface-external-cloud-provider@release_1.33
 charm-lib-interface-kubernetes-cni @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kubernetes-cni@release_1.33
 charm-lib-interface-tokens @ git+https://github.com/charmed-kubernetes/charm-lib-interface-tokens@release_1.33
-charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps@release_1.33
 charm-lib-node-base @ git+https://github.com/charmed-kubernetes/layer-kubernetes-node-base@release_1.33#subdirectory=ops
 ops.interface_tls_certificates @ git+https://github.com/charmed-kubernetes/interface-tls-certificates@release_1.33#subdirectory=ops
 ops.interface_aws @ git+https://github.com/charmed-kubernetes/interface-aws-integration@release_1.33#subdirectory=ops
@@ -12,6 +11,7 @@ charmhelpers == 1.2.1
 cosl == 0.0.7
 charms.contextual-status == 0.0.0
 charms.reconciler == 0.0.0
+charms.kubernetes-snaps == 0.0.0
 jinja2 == 3.1.3
 ops == 2.17.1
 ops.interface-kube-control==0.2.0


### PR DESCRIPTION
## Overview
Change `charms.kubernetes-snaps` to a Python package.