### PR TITLE
Prepping for 1.35 Release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ charm-lib-interface-container-runtime @ git+https://github.com/charmed-kubernete
 charm-lib-interface-external-cloud-provider @ git+https://github.com/charmed-kubernetes/charm-lib-interface-external-cloud-provider@main
 charm-lib-interface-kubernetes-cni @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kubernetes-cni@main
 charm-lib-interface-tokens @ git+https://github.com/charmed-kubernetes/charm-lib-interface-tokens@main
-charm-lib-node-base @ git+https://github.com/charmed-kubernetes/layer-kubernetes-node-base@3d7b34bd10aa5ef8dfca4f671a6e4757ec6c153a#subdirectory=ops
+charm-lib-node-base @ git+https://github.com/charmed-kubernetes/layer-kubernetes-node-base@main#subdirectory=ops
 ops.interface_tls_certificates @ git+https://github.com/charmed-kubernetes/interface-tls-certificates@main#subdirectory=ops
 ops.interface_aws @ git+https://github.com/charmed-kubernetes/interface-aws-integration@main#subdirectory=ops
 ops.interface_gcp @ git+https://github.com/charmed-kubernetes/interface-gcp-integration@main#subdirectory=ops

--- a/tests/unit/test_actions.py
+++ b/tests/unit/test_actions.py
@@ -30,7 +30,7 @@ def test_upgrade_action_fails(upgrade_snaps: mock.Mock, harness):
     """Verify that the upgrade action runs the upgrade_snap method and reconciles."""
 
     def mock_upgrade(channel, event):
-        assert channel == "latest/edge"
+        assert channel == harness.model.config.get("channel")
         status.add(ops.BlockedStatus("snap-upgrade-failed"))
         event.fail("snap upgrade failed")
 


### PR DESCRIPTION
This pull request updates the `test_upgrade_action_fails` unit test to make the test more robust by asserting the `channel` argument dynamically from the model configuration, instead of using a hardcoded value.

* Testing improvement:
  * Updated the assertion in `test_upgrade_action_fails` to check that the `channel` argument matches the value from `harness.model.config`, ensuring the test adapts to configuration changes.