### PR TITLE
chore: mark optional endpoints as optional in metadata

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -235,21 +235,27 @@ provides:
     scope: container
   cos-agent:
     interface: cos_agent
+    optional: true
   ingress-proxy:
     interface: http
+    optional: true
 requires:
   aws:
     interface: aws-integration
+    optional: true
   gcp:
     interface: gcp-integration
+    optional: true
   azure:
     interface: azure-integration
+    optional: true
   certificates:
     interface: tls-certificates
   kube-control:
     interface: kube-control
   tokens:
     interface: tokens
+    optional: true
 
 resources:
   cni-plugins:


### PR DESCRIPTION
Mark `aws`, `gcp`, `azure`, `tokens` (requires) and `cos-agent`, `ingress-proxy` (provides) as `optional: true`. Cloud integrations are mutually exclusive and each is gated on relation presence; tokens and observability endpoints are non-blocking when absent.