### PR TITLE
fix: configure LXD security.nesting for charmcraft on LXD 6.x

### DIFF
--- a/.github/workflows/vsphere-integration.yaml
+++ b/.github/workflows/vsphere-integration.yaml
@@ -30,6 +30,14 @@ jobs:
             --model-default datastore=vsanDatastore
             --model-default primary-network=VLAN_2763
             --model-default force-vm-hardware-version=17
+      - name: Configure LXD for charmcraft
+        run: |
+          # LXD 6.x requires security.nesting=true for snapd to run inside
+          # charmcraft's managed build containers. Also purge any containers
+          # cached from an older LXD version to avoid stale state.
+          sudo lxc profile set default security.nesting true
+          sudo lxc list --format csv -c n | grep charmcraft | \
+            xargs -I{} sudo lxc delete --force {} || true
       - name: Run test
         run: tox -e integration -- --basetemp=/home/ubuntu/pytest
       - name: Setup Debug Artifact Collection


### PR DESCRIPTION
## Problem

After `actions-operator` upgrades LXD from 5.0 → 6.8 (`snap refresh lxd --channel=latest/stable`), charmcraft fails to build the charm with:

```
Failed to enable snapd service.
* Command: systemctl restart snapd.service
* Exit code: 1
```

LXD 6.x disables nesting by default. Charmcraft's managed build containers need to run snapd inside them (`security.nesting=true`).

Additionally, any base containers cached from the old LXD version become stale after the upgrade and must be purged.

## Fix

Add a step after `Setup operator environment` to:
1. Set `security.nesting=true` on the default LXD profile
2. Purge stale charmcraft base containers

This is a minimal, targeted fix — no build mode changes needed.