### PR TITLE
docs: document dashboard addon removal and migration path

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,27 @@ More information: https://charmhub.io/kubernetes-worker
 
 Describe your charm in one or two sentences.
 
+## What changed: Kubernetes Dashboard addon removal
+
+From CK 1.36, the Kubernetes Dashboard addon is no longer managed by `cdk-addons`.
+The legacy `enable-dashboard` and `dashboard-auth` options are removed and are unset on upgrade.
+If you previously relied on the addon, deploy and manage Dashboard directly from upstream.
+
+### Migration path
+
+The Kubernetes Dashboard is no longer maintained by Charmed Kubernetes and receives
+no security updates through this distribution. Canonical recommends **not** running it
+in production environments.
+
+If you still need the dashboard, you can deploy it directly from the upstream project —
+accepting that support and security patching become your own responsibility:
+
+```bash
+helm upgrade --install kubernetes-dashboard kubernetes-dashboard \
+  --repo https://kubernetes.github.io/dashboard \
+  --namespace kubernetes-dashboard --create-namespace
+```
+
 ## Other resources
 
 <!-- If your charm is documented somewhere else other than Charmhub, provide a link separately. -->


### PR DESCRIPTION
## Summary

Docs-only update to reflect the Kubernetes Dashboard addon removal in CK 1.36.

## Changes

- **`README.md`**: Added a "What changed" section noting that the dashboard addon is no longer managed by `cdk-addons`, that `enable-dashboard` and `dashboard-auth` options are removed on upgrade, and that Canonical does not recommend running the dashboard in production. Includes an upstream Helm-based migration path for operators who still need it.

## Scope

Docs-only. No code or behaviour changes.